### PR TITLE
Create fixture directory in repo

### DIFF
--- a/spec/fixture/.gitignore
+++ b/spec/fixture/.gitignore
@@ -1,0 +1,2 @@
+mnist
+!.gitignore


### PR DESCRIPTION
For mnist fixture loading to work properly the fixture directory must… exist. Ask git to ignore mnist sub-directory