### PR TITLE
Redefine `.new` to Raise an Error

### DIFF
--- a/lib/mxnet/ndarray.rb
+++ b/lib/mxnet/ndarray.rb
@@ -2,6 +2,12 @@ module MXNet
   class NDArray
     include Enumerable
 
+    class << self
+      def new
+        raise NotImplementedError.new("use MXNet::NDArray.array() or similar")
+      end
+    end
+
     def self.ones(shape, ctx=nil, dtype=:float32, **kwargs)
       ctx ||= Context.default
       dtype = Utils.dtype_id(dtype)

--- a/spec/mxnet/ndarray_spec.rb
+++ b/spec/mxnet/ndarray_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 module MXNet
   ::RSpec.describe NDArray do
+    describe '.new' do
+      specify do
+        expect { MXNet::NDArray.new }.to raise_error(NotImplementedError)
+      end
+    end
+
     describe '#[]' do
       context 'when the array is 1D' do
         specify do


### PR DESCRIPTION
Invoking `MXNet::NDArray.new` constructs an invalid instance. Specifically, `ndarray_allocate()` is called but a handle is never allocated, so future calls to `mxnet_ndarray_get_handle()` return `NULL` which breaks code that doesn't deal with this case (specifically in my case the Ruby executable crashes when I try to do anything with this instance).

There isn't any obvious use case for `MXNet::NDArray.new` and the Python API doesn't have an equivalent, so simply redefine it to raise an error.
