### PR TITLE
Symbolize dtype value

### DIFF
--- a/ext/mxnet/ndarray.c
+++ b/ext/mxnet/ndarray.c
@@ -396,12 +396,6 @@ ndarray_get_dtype_id(VALUE obj)
 static VALUE
 ndarray_get_dtype(VALUE obj)
 {
-  return INT2NUM(ndarray_get_dtype_id(obj));
-}
-
-static VALUE
-ndarray_get_dtype_name(VALUE obj)
-{
   int dtype_id = ndarray_get_dtype_id(obj);
   return mxnet_dtype_id2name(dtype_id);
 }
@@ -733,7 +727,6 @@ mxnet_init_ndarray(void)
   /* TODO: rb_define_singleton_method(cNDArray, "load_from_buffer", ndarray_s_load_from_buffer, 1); */
 
   rb_define_method(cNDArray, "dtype", ndarray_get_dtype, 0);
-  rb_define_method(cNDArray, "dtype_name", ndarray_get_dtype_name, 0);
   rb_define_method(cNDArray, "shape", mxnet_ndarray_get_shape, 0);
   rb_define_method(cNDArray, "reshape", ndarray_reshape, 1);
   rb_define_method(cNDArray, "grad", ndarray_grad, 0);

--- a/spec/mxnet/dtype_spec.rb
+++ b/spec/mxnet/dtype_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe MXNet::DType do
+  describe '.id2name' do
+    def id2name(id)
+      MXNet::DType.id2name(id)
+    end
+
+    specify do
+      expect(id2name(0)).to eq(:float32)
+    end
+  end
+
+  describe '.name2id' do
+    def name2id(name)
+      MXNet::DType.name2id(name)
+    end
+
+    specify do
+      expect(name2id(:float32)).to eq(0)
+    end
+
+    specify do
+      expect(name2id('float32')).to eq(0)
+    end
+  end
+end
+
+RSpec.describe 'dtype' do
+  specify 'dtype is always symbol' do
+    x = MXNet::NDArray.zeros([3])
+    expect(x.dtype).to eq(:float32)
+  end
+
+  specify 'dtype can be specified as a string' do
+    x = MXNet::NDArray.zeros([3], dtype: 'float32')
+    expect(x.dtype).to eq(:float32)
+
+    x = MXNet::NDArray.zeros([3], dtype: 'float64')
+    expect(x.dtype).to eq(:float64)
+  end
+
+  specify 'dtype can be specified as an integer' do
+    x = MXNet::NDArray.zeros([3], dtype: 'float32')
+    expect(x.dtype).to eq(:float32)
+
+    x = MXNet::NDArray.zeros([3], dtype: 'float64')
+    expect(x.dtype).to eq(:float64)
+  end
+end

--- a/spec/mxnet/narray_helper/ndarray_spec.rb
+++ b/spec/mxnet/narray_helper/ndarray_spec.rb
@@ -47,11 +47,11 @@ module MXNet
       specify do
         x = Numo::Int8.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(Numo::SFloat.cast(x))
 
         y = MXNet::NDArray(x, dtype: :int8)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:int8))
+        expect(y.dtype).to eq(:int8)
         expect(y.to_narray).to eq(x)
       end
     end
@@ -60,7 +60,7 @@ module MXNet
       specify do
         x = Numo::Int32.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(Numo::SFloat.cast(x))
       end
     end
@@ -69,11 +69,11 @@ module MXNet
       specify do
         x = Numo::Int32.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(Numo::SFloat.cast(x))
 
         y = MXNet::NDArray(x, dtype: :int32)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:int32))
+        expect(y.dtype).to eq(:int32)
         expect(y.to_narray).to eq(x)
       end
     end
@@ -82,11 +82,11 @@ module MXNet
       specify do
         x = Numo::Int64.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(Numo::SFloat.cast(x))
 
         y = MXNet::NDArray(x, dtype: :int64)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:int64))
+        expect(y.dtype).to eq(:int64)
         expect(y.to_narray).to eq(x)
       end
     end
@@ -95,11 +95,11 @@ module MXNet
       specify do
         x = Numo::UInt8.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(Numo::SFloat.cast(x))
 
         y = MXNet::NDArray(x, dtype: :uint8)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:uint8))
+        expect(y.dtype).to eq(:uint8)
         expect(y.to_narray).to eq(x)
       end
     end
@@ -108,7 +108,7 @@ module MXNet
       specify do
         x = Numo::UInt16.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(Numo::SFloat.cast(x))
       end
     end
@@ -117,7 +117,7 @@ module MXNet
       specify do
         x = Numo::UInt32.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(Numo::SFloat.cast(x))
       end
     end
@@ -126,7 +126,7 @@ module MXNet
       specify do
         x = Numo::UInt64.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(Numo::SFloat.cast(x))
       end
     end
@@ -135,7 +135,7 @@ module MXNet
       specify do
         x = Numo::SFloat.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(x)
       end
     end
@@ -144,11 +144,11 @@ module MXNet
       specify do
         x = Numo::DFloat.ones(2, 3)
         y = MXNet::NDArray(x)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float32))
+        expect(y.dtype).to eq(:float32)
         expect(y.to_narray).to eq(Numo::SFloat.cast(x))
 
         y = MXNet::NDArray(x, dtype: :float64)
-        expect(y.dtype).to eq(MXNet::DType.name2id(:float64))
+        expect(y.dtype).to eq(:float64)
         expect(y.to_narray).to eq(x)
       end
     end

--- a/spec/mxnet/ndarray_spec.rb
+++ b/spec/mxnet/ndarray_spec.rb
@@ -776,7 +776,6 @@ module MXNet
       let(:y) { MXNet::NDArray.zeros([2, 3]) }
 
       specify "slice along all axes" do
-        pending "slice_like unknown from Ops (operation delegator)"
         expect(x.slice_like(y).to_narray).to eq(
           [[1, 2, 3],
            [5, 6, 7]]
@@ -784,24 +783,21 @@ module MXNet
       end
 
       specify "slice along axis 0 and 1 (same as above)" do
-        pending "slice_like unknown from Ops (operation delegator)"
-        expect(x.slice_like(shape_like: y, axes: [0, 1]).to_narray).to eq(
+        expect(x.slice_like(y, axes: [0, 1]).to_narray).to eq(
           [[1, 2, 3],
            [5, 6, 7]]
         )
       end
 
       specify "slice along axis 0" do
-        pending "slice_like unknown from Ops (operation delegator)"
-        expect(x.slice_like(shape_like: y, axes: [0]).to_narray).to eq(
+        expect(x.slice_like(y, axes: [0]).to_narray).to eq(
           [[1, 2, 3, 4],
            [5, 6, 7, 8]]
         )
       end
 
       specify "slice along axis -1" do
-        pending "slice_like unknown from Ops (operation delegator)"
-        expect(x.slice_like(shape_like: y, axes: [-1]).to_narray).to eq(
+        expect(x.slice_like(y, axes: [-1]).to_narray).to eq(
           [[1, 2, 3],
            [5, 6, 7],
            [9, 10, 11]]

--- a/spec/mxnet/ndarray_spec.rb
+++ b/spec/mxnet/ndarray_spec.rb
@@ -155,14 +155,14 @@ module MXNet
 
     describe '#dtype' do
       specify do
-        expect(MXNet::NDArray.empty([1, 2]).dtype).to eq(DType.name2id(:float32))
-        expect(MXNet::NDArray.empty([1, 2], dtype: :float32).dtype).to eq(DType.name2id(:float32))
-        expect(MXNet::NDArray.empty([1, 2], dtype: :float64).dtype).to eq(DType.name2id(:float64))
-        expect(MXNet::NDArray.empty([1, 2], dtype: :float16).dtype).to eq(DType.name2id(:float16))
-        expect(MXNet::NDArray.empty([1, 2], dtype: :uint8).dtype).to eq(DType.name2id(:uint8))
-        expect(MXNet::NDArray.empty([1, 2], dtype: :int8).dtype).to eq(DType.name2id(:int8))
-        expect(MXNet::NDArray.empty([1, 2], dtype: :int32).dtype).to eq(DType.name2id(:int32))
-        expect(MXNet::NDArray.empty([1, 2], dtype: :int64).dtype).to eq(DType.name2id(:int64))
+        expect(MXNet::NDArray.empty([1, 2]).dtype).to eq(:float32)
+        expect(MXNet::NDArray.empty([1, 2], dtype: :float32).dtype).to eq(:float32)
+        expect(MXNet::NDArray.empty([1, 2], dtype: :float64).dtype).to eq(:float64)
+        expect(MXNet::NDArray.empty([1, 2], dtype: :float16).dtype).to eq(:float16)
+        expect(MXNet::NDArray.empty([1, 2], dtype: :uint8).dtype).to eq(:uint8)
+        expect(MXNet::NDArray.empty([1, 2], dtype: :int8).dtype).to eq(:int8)
+        expect(MXNet::NDArray.empty([1, 2], dtype: :int32).dtype).to eq(:int32)
+        expect(MXNet::NDArray.empty([1, 2], dtype: :int64).dtype).to eq(:int64)
       end
     end
 
@@ -237,7 +237,7 @@ module MXNet
       specify do
         x = MXNet::NDArray.zeros([2, 3], dtype: :float32)
         y = x.as_type(:int32)
-        expect(y.dtype_name).to eq(:int32)
+        expect(y.dtype).to eq(:int32)
       end
     end
 


### PR DESCRIPTION
I'd like to symbolize the value of dtype.
Currently NDArray#dtype returns an integer value that corresponds to a specific dtype.