### PR TITLE
Clean up Usage of rb_check_convert_type(...)

### DIFF
--- a/ext/mxnet/libmxnet.c
+++ b/ext/mxnet/libmxnet.c
@@ -124,11 +124,11 @@ imperative_invoke(VALUE mod, VALUE handle, VALUE ndargs, VALUE keys, VALUE vals,
   void **inputs, **outputs = NULL;
   char const **params_keys, **params_vals;
 
-  ndargs = rb_check_convert_type(ndargs, T_ARRAY, "Array", "to_ary");
-  keys = rb_check_convert_type(keys, T_ARRAY, "Array", "to_ary");
-  vals = rb_check_convert_type(vals, T_ARRAY, "Array", "to_ary");
+  ndargs = rb_convert_type(ndargs, T_ARRAY, "Array", "to_ary");
+  keys = rb_convert_type(keys, T_ARRAY, "Array", "to_ary");
+  vals = rb_convert_type(vals, T_ARRAY, "Array", "to_ary");
   if (!NIL_P(out) && !RTEST(rb_obj_is_kind_of(out, mxnet_cNDArray))) {
-    out = rb_check_convert_type(out, T_ARRAY, "Array", "to_ary");
+    out = rb_convert_type(out, T_ARRAY, "Array", "to_ary");
   }
 
   num_inputs = (int)RARRAY_LEN(ndargs);
@@ -164,7 +164,7 @@ imperative_invoke(VALUE mod, VALUE handle, VALUE ndargs, VALUE keys, VALUE vals,
       outputs[0] = mxnet_ndarray_get_handle(out);
     }
     else {
-      out = rb_check_convert_type(out, T_ARRAY, "Array", "to_ary");
+      out = rb_convert_type(out, T_ARRAY, "Array", "to_ary");
       if (RARRAY_LEN(out) > INT_MAX) {
         rb_raise(rb_eArgError, "too many outputs (%ld)", RARRAY_LEN(out));
       }
@@ -227,8 +227,8 @@ symbol_creator(VALUE mod, VALUE handle, VALUE args, VALUE kwargs, VALUE keys, VA
   char const **params_keys, **params_vals, **sym_keys;
   void **sym_handle, **sym_args;
 
-  keys = rb_check_convert_type(keys, T_ARRAY, "Array", "to_ary");
-  vals = rb_check_convert_type(vals, T_ARRAY, "Array", "to_ary");
+  keys = rb_convert_type(keys, T_ARRAY, "Array", "to_ary");
+  vals = rb_convert_type(vals, T_ARRAY, "Array", "to_ary");
 
   num_params = (int)RARRAY_LEN(keys);
   keys_str = rb_str_tmp_new(sizeof(char const **)*num_params);

--- a/ext/mxnet/ndarray.c
+++ b/ext/mxnet/ndarray.c
@@ -346,7 +346,7 @@ ndarray_reshape(VALUE obj, VALUE shape_v)
   int ndim, *dims, i;
 
   handle = mxnet_ndarray_get_handle(obj);
-  shape_v = rb_check_convert_type(shape_v, T_ARRAY, "Array", "to_ary");
+  shape_v = rb_convert_type(shape_v, T_ARRAY, "Array", "to_ary");
 
   /* TODO: check INT_MAX */
   ndim = (int)RARRAY_LEN(shape_v);

--- a/spec/mxnet/ndarray_spec.rb
+++ b/spec/mxnet/ndarray_spec.rb
@@ -146,6 +146,7 @@ module MXNet
         expect(x.reshape([3, 2]).shape).to eq([3, 2])
         expect(x.reshape([2, 2]).shape).to eq([2, 2])
         expect { x.reshape([2, 2, 2]) }.to raise_error(MXNet::Error, /target shape size is larger current shape/)
+        expect { x.reshape({1 => 2}) }.to raise_error(TypeError, /no implicit conversion of Hash into Array/)
       end
     end
 


### PR DESCRIPTION
Replace with `rb_convert_type(...)`, which automatically raises `TypeError`.

I added a test for the obvious/easy to test case: `a.reshape({1 => 2})`.
