### PR TITLE
Implement Basic Gluon

### DIFF
--- a/ext/mxnet/autograd.c
+++ b/ext/mxnet/autograd.c
@@ -172,7 +172,7 @@ autograd_s_backward(int argc, VALUE *argv, VALUE mod)
 
     head_grads = rb_convert_type(head_grads, T_ARRAY, "Array", "to_ary");
     if (RARRAY_LEN(heads) != RARRAY_LEN(head_grads)) {
-      rb_raise(rb_eArgError, "haeds and head_grads must be arrays of the same length");
+      rb_raise(rb_eArgError, "heads and head_grads must be arrays of the same length");
     }
 
     head_grad_handles_str = rb_str_tmp_new(sizeof(NDArrayHandle) * heads_len);

--- a/ext/mxnet/autograd.c
+++ b/ext/mxnet/autograd.c
@@ -57,7 +57,7 @@ autograd_s_mark_variables(int argc, VALUE *argv, VALUE mod)
 {
   int state = 0;
   VALUE result;
-  struct mark_variables_args args;
+  struct mark_variables_args args = {0};
 
   rb_scan_args(argc, argv, "2:", &args.vars, &args.grads, &args.opts);
 

--- a/ext/mxnet/cached_op.c
+++ b/ext/mxnet/cached_op.c
@@ -1,0 +1,208 @@
+#include "mxnet_internal.h"
+
+VALUE cCachedOp;
+
+static void
+cached_op_free(void *ptr)
+{
+  if (ptr != NULL) {
+    CHECK_CALL(MXNET_API(MXFreeCachedOp)((CachedOpHandle)ptr));
+  }
+}
+
+static size_t
+cached_op_memsize(void const *ptr)
+{
+  return 0;
+}
+
+static const rb_data_type_t cached_op_data_type = {
+  "MXNet::CachedOp",
+  {
+    NULL,
+    cached_op_free,
+    cached_op_memsize,
+  },
+  0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static VALUE
+cached_op_allocate(VALUE klass)
+{
+  return TypedData_Wrap_Struct(klass, &cached_op_data_type, NULL);
+}
+
+struct create_cached_op_args {
+  SymbolHandle symbol_handle;
+  CachedOpHandle cached_op_handle;
+  mx_uint num_params;
+  char const **keys;
+  char const **vals;
+  int cursor;
+};
+
+static VALUE
+call_create_cached_op(VALUE value) {
+  struct create_cached_op_args *cargs = (struct create_cached_op_args *)value;
+
+  CHECK_CALL(MXNET_API(MXCreateCachedOpEx)(cargs->symbol_handle,
+                                           cargs->num_params,
+                                           cargs->keys,
+                                           cargs->vals,
+                                           &cargs->cached_op_handle));
+
+  return Qnil;
+}
+
+static int
+check_opts(VALUE key, VALUE val, VALUE opts)
+{
+  if (SYMBOL_P(key)) {
+    key = rb_sym_to_s(key);
+  }
+  StringValue(key);
+
+  if (TYPE(val) != T_STRING) {
+    val = rb_sprintf("%" PRIsVALUE, val);
+  }
+  StringValue(val);
+
+  rb_hash_aset(opts, key, val);
+
+  return ST_CONTINUE;
+}
+
+static int
+collect_opts(VALUE key, VALUE val, VALUE value)
+{
+  struct create_cached_op_args *args = (struct create_cached_op_args *)value;
+
+  args->keys[args->cursor] = StringValueCStr(key);
+  args->vals[args->cursor] = StringValueCStr(val);
+  ++args->cursor;
+
+  return ST_CONTINUE;
+}
+
+static VALUE
+cached_op_initialize(int argc, VALUE *argv, VALUE obj)
+{
+  int state = 0;
+  VALUE sym, opts, temp, result;
+  struct create_cached_op_args cargs = {0};
+  unsigned long n;
+
+  rb_scan_args(argc, argv, "1:", &sym, &opts);
+
+  if (!RTEST(rb_obj_is_kind_of(sym, mxnet_cSymbol))) {
+    rb_raise(rb_eTypeError, "wrong argument type %s (expected %"PRIsVALUE")",
+             rb_obj_classname(sym), mxnet_cSymbol);
+  }
+  if (NIL_P(opts)) {
+    opts = rb_hash_new();
+  }
+
+  n = RHASH_SIZE(opts);
+
+  temp = rb_hash_new();
+  rb_hash_foreach(opts, check_opts, temp);
+  opts = temp;
+
+  cargs.num_params = (mx_uint)n;
+  cargs.keys = ALLOC_N(const char *, n);
+  cargs.vals = ALLOC_N(const char *, n);
+  cargs.cursor = 0;
+
+  rb_hash_foreach(opts, collect_opts, (VALUE)&cargs);
+
+  cargs.symbol_handle = (SymbolHandle)mxnet_get_handle(sym);
+
+  result = rb_protect((VALUE (*)(VALUE))call_create_cached_op, (VALUE)&cargs, &state);
+
+  xfree(cargs.keys);
+  xfree(cargs.vals);
+
+  if (state) {
+    rb_jump_tag(state);
+  }
+
+  DATA_PTR(obj) = cargs.cached_op_handle;
+
+  return obj;
+}
+
+struct invoke_cached_op_args {
+  CachedOpHandle cached_op_handle;
+  int num_inputs, num_outputs, *out_stypes;
+  NDArrayHandle *inputs, *outputs;
+};
+
+static VALUE
+call_invoke_cached_op(VALUE value) {
+  struct invoke_cached_op_args *cargs = (struct invoke_cached_op_args *)value;
+
+  CHECK_CALL(MXNET_API(MXInvokeCachedOpEx)(cargs->cached_op_handle,
+                                           cargs->num_inputs,
+                                           cargs->inputs,
+                                           &cargs->num_outputs,
+                                           &cargs->outputs,
+                                           &cargs->out_stypes));
+
+  return Qnil;
+}
+
+static VALUE
+cached_op_call(VALUE obj, VALUE args)
+{
+  int state = 0;
+  VALUE result;
+  struct invoke_cached_op_args cargs = {0};
+  unsigned long i, n;
+
+  n = RARRAY_LEN(args);
+
+  cargs.num_inputs = (mx_uint)n;
+  cargs.inputs = ALLOC_N(NDArrayHandle, n);
+
+  for (i = 0; i < n; ++i) {
+    cargs.inputs[i] = mxnet_ndarray_get_handle(RARRAY_AREF(args, i));
+  }
+
+  cargs.cached_op_handle = (CachedOpHandle)DATA_PTR(obj);
+
+  result = rb_protect((VALUE (*)(VALUE))call_invoke_cached_op, (VALUE)&cargs, &state);
+
+  xfree(cargs.inputs);
+
+  if (state) {
+    rb_jump_tag(state);
+  }
+
+  if (cargs.num_outputs == 0) {
+    return Qnil;
+  }
+  else if (cargs.num_outputs == 1) {
+    return mxnet_ndarray_new(cargs.outputs[0]);
+  }
+
+  n = cargs.num_outputs;
+
+  result = rb_ary_new2(n);
+
+  for (i = 0; i < n; ++i) {
+    rb_ary_push(result, mxnet_ndarray_new(cargs.outputs[i]));
+  }
+
+  return result;
+}
+
+void
+mxnet_init_cached_op(void)
+{
+  cCachedOp = rb_define_class_under(mxnet_mMXNet, "CachedOp", rb_cObject);
+
+  rb_define_alloc_func(cCachedOp, cached_op_allocate);
+
+  rb_define_private_method(cCachedOp, "initialize", cached_op_initialize, -1);
+  rb_define_method(cCachedOp, "call", cached_op_call, -2);
+}

--- a/ext/mxnet/libmxnet.c
+++ b/ext/mxnet/libmxnet.c
@@ -113,6 +113,10 @@ init_api_table(VALUE handle)
   INIT_API_TABLE_ENTRY(MXSymbolInferType);
   INIT_API_TABLE_ENTRY(MXSymbolSaveToFile);
   INIT_API_TABLE_ENTRY(MXSymbolSaveToJSON);
+
+  INIT_API_TABLE_ENTRY(MXCreateCachedOpEx);
+  INIT_API_TABLE_ENTRY(MXFreeCachedOp);
+  INIT_API_TABLE_ENTRY(MXInvokeCachedOpEx);
 }
 
 static VALUE

--- a/ext/mxnet/mxnet.c
+++ b/ext/mxnet/mxnet.c
@@ -123,6 +123,8 @@ Init_mxnet(void)
 
   mxnet_init_autograd();
 
+  mxnet_init_cached_op();
+
   mxnet_init_executor();
 
   mxnet_init_io();

--- a/ext/mxnet/mxnet_internal.h
+++ b/ext/mxnet/mxnet_internal.h
@@ -72,6 +72,7 @@ typedef unsigned LONG_LONG uint64_t;
 
 typedef unsigned int mx_uint;
 typedef float mx_float;
+typedef void *CachedOpHandle;
 typedef void *ExecutorHandle;
 typedef void *DataIterCreator;
 typedef void *DataIterHandle;
@@ -288,6 +289,19 @@ struct mxnet_api_table {
                             int *complete);
   int (* MXSymbolSaveToFile)(SymbolHandle symbol, const char *fname);
   int (* MXSymbolSaveToJSON)(SymbolHandle symbol, const char **out_json);
+
+  int (* MXCreateCachedOpEx)(SymbolHandle symbol,
+                             int num_flags,
+                             const char **keys,
+                             const char **vals,
+                             CachedOpHandle *cached_op);
+  int (* MXFreeCachedOp)(CachedOpHandle cached_op);
+  int (* MXInvokeCachedOpEx)(CachedOpHandle cached_op,
+                             int num_inputs,
+                             NDArrayHandle *inputs,
+                             int *num_outputs,
+                             NDArrayHandle **outputs,
+                             int **out_stypes);
 };
 
 struct mxnet_api_table *mxnet_get_api_table(void);
@@ -321,6 +335,7 @@ VALUE mxnet_symbol_list_outputs(VALUE obj);
 
 void mxnet_init_libmxnet(void);
 void mxnet_init_autograd(void);
+void mxnet_init_cached_op(void);
 void mxnet_init_executor(void);
 void mxnet_init_io(void);
 void mxnet_init_ndarray(void);

--- a/lib/mxnet.rb
+++ b/lib/mxnet.rb
@@ -31,4 +31,5 @@ module MXNet
   require 'mxnet/ndarray/operations'
   require 'mxnet/symbol/operations'
   require 'mxnet/lr_scheduler'
+  require 'mxnet/initializer'
 end

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -304,11 +304,11 @@ module MXNet::Gluon
       name = sym.to_s
       if name[-1] == '='
         args.length == 1 or
-          raise ArgumentError, "wrong number of arguments (#{args.length} for 1)"
+          raise ArgumentError, "wrong number of arguments (#{args.length} for 1) to `#{sym}'"
         set_attr(name[0...-1], *args)
       else
         args.length == 0 or
-          raise ArgumentError, "wrong number of arguments (#{args.length} for 0)"
+          raise ArgumentError, "wrong number of arguments (#{args.length} for 0) to `#{sym}'"
         get_attr(name)
       end
     end

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -1,0 +1,155 @@
+require 'mxnet/gluon'
+require 'mxnet/gluon/parameter'
+require 'mxnet/ndarray'
+
+module MXNet::Gluon
+  ##
+  # Scope for collecting child Blocks.
+  #
+  class BlockScope
+    def self.create(prefix, params, hint)
+      if prefix.nil?
+        prefix = hint + '_'
+      end
+      if params.nil?
+        params = ParameterDict.new(prefix: prefix)
+      else
+        params = ParameterDict.new(prefix: prefix, params: params)
+      end
+      [prefix, params]
+    end
+  end
+  ##
+  # Base class for all neural network layers and models. Your models
+  # should subclass this class.
+  #
+  class Block
+    def initialize(prefix: nil, params: nil, **kwargs)
+      super()
+      @prefix, @params = BlockScope.create(prefix, params, hint)
+      @reg_parameters = {}
+    end
+    ##
+    # Prefix of this Block.
+    #
+    attr_reader :prefix
+    ##
+    # Returns this Block's ParameterDict (does not include its
+    # children's parameters).
+    #
+    attr_reader :params
+    ##
+    # Returns a ParameterDict containing this Block's and all of its
+    # children's Parameters. Also can return the Parameters that match
+    # some given regular expressions.
+    #
+    # For example, collect the specified Parameters for
+    # 'conv1_weight', 'conv1_bias', 'fc_weight' and 'fc_bias':
+    #
+    #     model.collect_params('conv1_weight|conv1_bias|fc_weight|fc_bias')
+    #
+    # or, alternatively, collect all parameters whose names end with
+    # 'weight' or 'bias':
+    #
+    #     model.collect_params('.*weight|.*bias')
+    #
+    # ====Parameters
+    #
+    # +select+:: (regexp) Regular expressions to match Parameters.
+    #
+    # ====Returns
+    #
+    # The filtered ParameterDict.
+    #
+    def collect_params(select = nil)
+      ret = ParameterDict.new(prefix: @params.prefix)
+      if select
+        ret.update(@params.select { |k, v| k =~ select })
+      else
+        ret.update(@params)
+      end
+      ret
+    end
+    ##
+    # Calls #forward. Only accepts positional arguments.
+    #
+    #
+    def [](*args)
+      forward(*args)
+    end
+    ##
+    # Override to implement forward computation using NDArray. Only
+    # accepts positional arguments.
+    #
+    # ====Parameters
+    #
+    # +args+:: (array of NDArray) Input tensors.
+    #
+    def forward(*args)
+      raise NotImplementedError
+    end
+    private
+    def method_missing(name, value = nil)
+      name = name.to_s
+      if name[-1] == '='
+        name = name[0...-1]
+        case value
+        when MXNet::Gluon::Block
+        when MXNet::Gluon::Parameter
+          @reg_parameters[name] = value
+        else
+          raise NoMethodError
+        end
+      else
+        @reg_parameters[name] or
+          raise NoMethodError
+      end
+    end
+    def hint
+      self.class.name.split('::').last.downcase
+    end
+  end
+  ##
+  # HybridBlock supports forwarding with both Symbol and NDArray.
+  #
+  class HybridBlock < Block
+    def initialize(**kwargs)
+      super(**kwargs)
+    end
+    ##
+    # Defines the forward computation. Arguments can be either Symbol
+    # or NDArray.
+    #
+    # ====Parameters
+    #
+    # +args+:: (array of Symbol or NDArray) Input tensors.
+    #
+    def forward(*args)
+      case args.first
+      when MXNet::Symbol
+        kwargs = {}
+        hybrid_forward(MXNet::Symbol, *args, **kwargs)
+      when MXNet::NDArray
+        ctx = args.first.context
+        kwargs = @reg_parameters.inject({}) do |acc, (i, j)|
+          acc[i.to_sym] = j.data(ctx: ctx)
+          acc
+        end
+        hybrid_forward(MXNet::NDArray, *args, **kwargs)
+      else
+        raise ArgumentError, 'only Symbol or NDArray are supported'
+      end
+    end
+    ##
+    # Override to construct symbolic graph for this Block.
+    #
+    # ====Parameters
+    #
+    # +args+:: (array of NDArray or Symbol) Input tensors.
+    #
+    #
+    def hybrid_forward(clazz, *args)
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -128,6 +128,23 @@ module MXNet::Gluon
       @reg_children.values
     end
     ##
+    # Initializes parameters of this block and its children.
+    # Equivalent to `self.collect_params.init(...)`.
+    #
+    # ====Parameters
+    #
+    # +init+::         (Initializer, default +nil+)
+    #                  The initializer to use.
+    # +ctx+::          (Context or array of Contexts, default +nil+)
+    #                  Desired contexts.
+    # +force_reinit+:: (boolean, default false)
+    #                  Whether to force re-initialization if parameter
+    #                  is already initialized.
+    #
+    def init(init: nil, ctx: nil, force_reinit: false)
+      collect_params.init(init: init, ctx: ctx, force_reinit: force_reinit)
+    end
+    ##
     # Returns a ParameterDict containing this Block's and all of its
     # children's Parameters. Also can return the Parameters that match
     # some given regular expressions.

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -51,8 +51,47 @@ module MXNet::Gluon
   # Base class for all neural network layers and models. Your models
   # should subclass this class.
   #
+  # Blocks can be nested recursively in a tree structure. You can
+  # create and assign child blocks as regular attributes. Blocks
+  # assigned this way will be registered and #collect_params will
+  # collect their parameters recursively. You can also manually
+  # register child blocks with #register_child.
+  #
+  #     class Model < MXNet::Gluon::Block
+  #       def initialize(**kwargs)
+  #         super(**kwargs)
+  #         self.with_name_scope do
+  #           self.dense0 = MXNet::Gluon::NN.Dense(20)
+  #           self.dense1 = MXNet::Gluon::NN.Dense(20)
+  #         end
+  #       end
+  #       def forward(input)
+  #         act = MXNet::Gluon::NN.Activation(:relu)
+  #         input = act[self.dense0[input]]
+  #         act[self.dense1[input]]
+  #       end
+  #     end
+  #
+  #     model = Model.new
+  #     model.collect_params.init
+  #     model[...]
+  #
   class Block
-    def initialize(prefix: nil, params: nil, **kwargs)
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +prefix+:: (string, optional)
+    #            Prefix acts like a name space. All child blocks
+    #            created inside the parent block's "name scope" (via
+    #            #with_name_scope) will have the parent block's prefix
+    #            in their name.
+    # +params+:: (ParameterDict, optional)
+    #            ParameterDict for sharing weights with the new
+    #            Block.
+    #
+    def initialize(prefix: nil, params: nil)
       @scope = BlockScope.new(self)
       @prefix, @params = BlockScope.create(prefix, params, hint)
       @reg_parameters = {}

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -180,6 +180,74 @@ module MXNet::Gluon
       ret
     end
     ##
+    # Saves parameters to file.
+    #
+    # Note that this method only saves parameters, not model
+    # structure. If you want to save model structures, use
+    # HybridBlock#export.
+    #
+    # For reference see: "Saving and Loading Gluon Models"
+    # (https://mxnet.incubator.apache.org/tutorials/gluon/save_load_params.html).
+    #
+    # ====Parameters
+    #
+    # +filename+:: (string)
+    #              Path to file.
+    #
+    def save_parameters(filename)
+      # NOTE: invoking private method on Parameter
+      params = collect_params_for_storage.transform_values { |p| p.send(:reduce) }
+      MXNet::NDArray.save(filename, params)
+    end
+    ##
+    # Loads parameters from file.
+    #
+    # For reference see: "Saving and Loading Gluon Models"
+    # (https://mxnet.incubator.apache.org/tutorials/gluon/save_load_params.html).
+    #
+    # ====Parameters
+    #
+    # +filename+::      (string)
+    #                   Path to file.
+    # +ctx+::           (Context or array of Context, default cpu)
+    #                   Context(s) to initialize loaded parameters on.
+    # +allow_missing+:: (boolean, default +false+)
+    #                   Whether to silently skip parameters not
+    #                   present in the file.
+    # +ignore_extra+::  (boolean, default +false+)
+    #                   Whether to silently ignore parameters not
+    #                   present in this block.
+    #
+    def load_parameters(filename, ctx = MXNet.cpu,
+                        allow_missing: false,
+                        ignore_extra: false)
+      params = collect_params_for_storage
+      loaded = MXNet::NDArray.load(filename)
+      unless allow_missing
+        params.each do |key, value|
+          unless loaded.has_key?(key)
+            raise RuntimeError,
+                  "Parameter '#{key}' is missing in file '#{filename}'. " \
+                  "Set allow_missing: true to ignore missing parameters."
+          end
+        end
+      end
+      unless ignore_extra
+        loaded.each do |key, value|
+          unless params.has_key?(key)
+            raise RuntimeError,
+                  "Parameter '#{key}' loaded from file '#{filename}' is " \
+                  "not present in this block. Set ignore_extra: true to " \
+                  "ignore extra parameters."
+          end
+        end
+      end
+      params.each do |key, value|
+        # NOTE: invoking private method on Parameter
+        params[key].send(:load_and_init, ctx, loaded[key])
+      end
+    end
+    ##
     # Registers block as a child of self. Blocks assigned as
     # attributes will be registered automatically.
     #
@@ -204,6 +272,18 @@ module MXNet::Gluon
     #
     def forward(*args)
       raise NotImplementedError
+    end
+    protected
+    def collect_params_for_storage(prefix = '')
+      prefix += '.' unless prefix.empty?
+      {}.tap do |hash|
+        @reg_parameters.each do |key, param|
+          hash[prefix + key] = param
+        end
+        @reg_children.each do |key, child|
+          hash.merge!(child.collect_params_for_storage(prefix + key))
+        end
+      end
     end
     private
     def method_missing(sym, *args)

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -83,6 +83,12 @@ module MXNet::Gluon
       @scope.call(self, &proc)
     end
     ##
+    # Returns this block's registered children.
+    #
+    def children
+      @reg_children.values
+    end
+    ##
     # Returns a ParameterDict containing this Block's and all of its
     # children's Parameters. Also can return the Parameters that match
     # some given regular expressions.
@@ -121,7 +127,8 @@ module MXNet::Gluon
     # Registers block as a child of self. Blocks assigned as
     # attributes will be registered automatically.
     #
-    def register_child(block, name)
+    def register_child(block, name = nil)
+      name = @reg_children.length.to_s if name.nil?
       @reg_children[name] = block
     end
     ##

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -2,706 +2,708 @@ require 'mxnet/gluon'
 require 'mxnet/gluon/parameter'
 require 'mxnet/ndarray'
 
-module MXNet::Gluon
-  ##
-  # Scope for collecting child Blocks.
-  #
-  class BlockScope
-    def initialize(block = nil)
-      @block = block
-      @counters = Hash.new(-1)
-    end
+module MXNet
+  module Gluon
+    ##
+    # Scope for collecting child Blocks.
+    #
+    class BlockScope
+      def initialize(block = nil)
+        @block = block
+        @counters = Hash.new(-1)
+      end
 
-    attr_accessor :block
-    attr_accessor :counters
+      attr_accessor :block
+      attr_accessor :counters
 
-    def self.create(prefix, params, hint)
-      current =
-        Thread.current['mxnet_gluon_blockscope_current'] ||=
-        BlockScope.new
-      if current.block
-        if prefix.nil?
-          prefix = "#{hint}#{current.counters[hint] += 1}_"
-        end
-        if params.nil?
-          params = ParameterDict.new(prefix: "#{current.block.prefix}#{prefix}")
+      def self.create(prefix, params, hint)
+        current =
+          Thread.current['mxnet_gluon_blockscope_current'] ||=
+          BlockScope.new
+        if current.block
+          if prefix.nil?
+            prefix = "#{hint}#{current.counters[hint] += 1}_"
+          end
+          if params.nil?
+            params = ParameterDict.new(prefix: "#{current.block.prefix}#{prefix}")
+          else
+            params = ParameterDict.new(prefix: "#{current.block.prefix}#{prefix}", shared: params)
+          end
+          ["#{current.block.prefix}#{prefix}", params]
         else
-          params = ParameterDict.new(prefix: "#{current.block.prefix}#{prefix}", shared: params)
+          if prefix.nil?
+            prefix = "#{hint}#{current.counters[hint] += 1}_"
+          end
+          if params.nil?
+            params = ParameterDict.new(prefix: prefix)
+          else
+            params = ParameterDict.new(prefix: params.prefix, shared: params)
+          end
+          [prefix, params]
         end
-        ["#{current.block.prefix}#{prefix}", params]
-      else
-        if prefix.nil?
-          prefix = "#{hint}#{current.counters[hint] += 1}_"
-        end
-        if params.nil?
-          params = ParameterDict.new(prefix: prefix)
-        else
-          params = ParameterDict.new(prefix: params.prefix, shared: params)
-        end
-        [prefix, params]
+      end
+
+      def call(block)
+        previous = Thread.current['mxnet_gluon_blockscope_current']
+        Thread.current['mxnet_gluon_blockscope_current'] = block.scope
+        yield
+      ensure
+        Thread.current['mxnet_gluon_blockscope_current'] = previous
       end
     end
 
-    def call(block)
-      previous = Thread.current['mxnet_gluon_blockscope_current']
-      Thread.current['mxnet_gluon_blockscope_current'] = block.scope
-      yield
-    ensure
-      Thread.current['mxnet_gluon_blockscope_current'] = previous
-    end
-  end
-
-  ##
-  # Base class for all neural network layers and models. Your models
-  # should subclass this class.
-  #
-  # Blocks can be nested recursively in a tree structure. You can
-  # create and assign child blocks as regular attributes. Blocks
-  # assigned this way will be registered and #collect_params will
-  # collect their parameters recursively. You can also manually
-  # register child blocks with #register_child.
-  #
-  #     class Model < MXNet::Gluon::Block
-  #       def initialize(**kwargs)
-  #         super(**kwargs)
-  #         self.with_name_scope do
-  #           self.dense0 = MXNet::Gluon::NN.Dense(20)
-  #           self.dense1 = MXNet::Gluon::NN.Dense(20)
-  #         end
-  #       end
-  #       def forward(input)
-  #         act = MXNet::Gluon::NN.Activation(:relu)
-  #         input = act[self.dense0[input]]
-  #         act[self.dense1[input]]
-  #       end
-  #     end
-  #
-  #     model = Model.new
-  #     model.collect_params.init
-  #     model[...]
-  #
-  class Block
     ##
-    # Creates a new instance.
+    # Base class for all neural network layers and models. Your models
+    # should subclass this class.
     #
-    # ====Parameters
+    # Blocks can be nested recursively in a tree structure. You can
+    # create and assign child blocks as regular attributes. Blocks
+    # assigned this way will be registered and #collect_params will
+    # collect their parameters recursively. You can also manually
+    # register child blocks with #register_child.
     #
-    # +prefix+:: (string, optional)
-    #            Prefix acts like a name space. All child blocks
-    #            created inside the parent block's "name scope" (via
-    #            #with_name_scope) will have the parent block's prefix
-    #            in their name.
-    # +params+:: (ParameterDict, optional)
-    #            ParameterDict for sharing weights with the new
-    #            Block.
-    #
-    def initialize(prefix: nil, params: nil)
-      @scope = BlockScope.new(self)
-      @prefix, @params = BlockScope.create(prefix, params, hint)
-      @reg_parameters = {}
-      @reg_children = {}
-      @reg_other = {}
-    end
-
-    ##
-    # Scope of this block.
-    #
-    attr_reader :scope
-
-    ##
-    # Prefix of this Block.
-    #
-    attr_reader :prefix
-
-    ##
-    # Returns this Block's ParameterDict (does not include its
-    # children's parameters).
-    #
-    attr_reader :params
-
-    ##
-    # Enters a name space managing Block names.
-    #
-    #     self.with_name_scope do
-    #       self.dense = MXNet::Gluon::NN.Dense(20)
+    #     class Model < MXNet::Gluon::Block
+    #       def initialize(**kwargs)
+    #         super(**kwargs)
+    #         self.with_name_scope do
+    #           self.dense0 = MXNet::Gluon::NN.Dense(20)
+    #           self.dense1 = MXNet::Gluon::NN.Dense(20)
+    #         end
+    #       end
+    #       def forward(input)
+    #         act = MXNet::Gluon::NN.Activation(:relu)
+    #         input = act[self.dense0[input]]
+    #         act[self.dense1[input]]
+    #       end
     #     end
     #
-    def with_name_scope(&proc)
-      @scope.call(self, &proc)
-    end
-
-    ##
-    # Returns this block's registered children.
+    #     model = Model.new
+    #     model.collect_params.init
+    #     model[...]
     #
-    def children
-      @reg_children.values
-    end
-
-    ##
-    # Initializes parameters of this block and its children.
-    # Equivalent to `self.collect_params.init(...)`.
-    #
-    # ====Parameters
-    #
-    # +init+::         (Initializer, default +nil+)
-    #                  The initializer to use.
-    # +ctx+::          (Context or array of Contexts, default +nil+)
-    #                  Desired contexts.
-    # +force_reinit+:: (boolean, default false)
-    #                  Whether to force re-initialization if parameter
-    #                  is already initialized.
-    #
-    def init(init: nil, ctx: nil, force_reinit: false)
-      collect_params.init(init: init, ctx: ctx, force_reinit: force_reinit)
-    end
-
-    ##
-    # Returns a ParameterDict containing this Block's and all of its
-    # children's Parameters. Also can return the Parameters that match
-    # some given regular expressions.
-    #
-    # For example, collect the specified Parameters for
-    # 'conv1_weight', 'conv1_bias', 'fc_weight' and 'fc_bias':
-    #
-    #     model.collect_params('conv1_weight|conv1_bias|fc_weight|fc_bias')
-    #
-    # or, alternatively, collect all parameters whose names end with
-    # 'weight' or 'bias':
-    #
-    #     model.collect_params('.*weight|.*bias')
-    #
-    # ====Parameters
-    #
-    # +select+:: (regexp) Regular expressions to match Parameters.
-    #
-    # ====Returns
-    #
-    # The filtered ParameterDict.
-    #
-    def collect_params(select = nil)
-      ret = ParameterDict.new(prefix: @params.prefix)
-      if select
-        ret.update(@params.select { |k, v| k =~ select })
-      else
-        ret.update(@params)
+    class Block
+      ##
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +prefix+:: (string, optional)
+      #            Prefix acts like a name space. All child blocks
+      #            created inside the parent block's "name scope" (via
+      #            #with_name_scope) will have the parent block's prefix
+      #            in their name.
+      # +params+:: (ParameterDict, optional)
+      #            ParameterDict for sharing weights with the new
+      #            Block.
+      #
+      def initialize(prefix: nil, params: nil)
+        @scope = BlockScope.new(self)
+        @prefix, @params = BlockScope.create(prefix, params, hint)
+        @reg_parameters = {}
+        @reg_children = {}
+        @reg_other = {}
       end
-      @reg_children.each do |_, child|
-        ret.update(child.collect_params(select))
+
+      ##
+      # Scope of this block.
+      #
+      attr_reader :scope
+
+      ##
+      # Prefix of this Block.
+      #
+      attr_reader :prefix
+
+      ##
+      # Returns this Block's ParameterDict (does not include its
+      # children's parameters).
+      #
+      attr_reader :params
+
+      ##
+      # Enters a name space managing Block names.
+      #
+      #     self.with_name_scope do
+      #       self.dense = MXNet::Gluon::NN.Dense(20)
+      #     end
+      #
+      def with_name_scope(&proc)
+        @scope.call(self, &proc)
       end
-      ret
-    end
 
-    ##
-    # Saves parameters to file.
-    #
-    # Note that this method only saves parameters, not model
-    # structure. If you want to save model structures, use
-    # HybridBlock#export.
-    #
-    # For reference see: "Saving and Loading Gluon Models"
-    # (https://mxnet.incubator.apache.org/tutorials/gluon/save_load_params.html).
-    #
-    # ====Parameters
-    #
-    # +filename+:: (string)
-    #              Path to file.
-    #
-    def save_parameters(filename)
-      # NOTE: invoking private method on Parameter
-      params = collect_params_for_storage.transform_values { |p| p.send(:reduce) }
-      MXNet::NDArray.save(filename, params)
-    end
+      ##
+      # Returns this block's registered children.
+      #
+      def children
+        @reg_children.values
+      end
 
-    ##
-    # Loads parameters from file.
-    #
-    # For reference see: "Saving and Loading Gluon Models"
-    # (https://mxnet.incubator.apache.org/tutorials/gluon/save_load_params.html).
-    #
-    # ====Parameters
-    #
-    # +filename+::      (string)
-    #                   Path to file.
-    # +ctx+::           (Context or array of Context, default cpu)
-    #                   Context(s) to initialize loaded parameters on.
-    # +allow_missing+:: (boolean, default +false+)
-    #                   Whether to silently skip parameters not
-    #                   present in the file.
-    # +ignore_extra+::  (boolean, default +false+)
-    #                   Whether to silently ignore parameters not
-    #                   present in this block.
-    #
-    def load_parameters(filename, ctx = MXNet.cpu,
-                        allow_missing: false,
-                        ignore_extra: false)
-      params = collect_params_for_storage
-      loaded = MXNet::NDArray.load(filename)
-      unless allow_missing
-        params.each do |key, value|
-          unless loaded.has_key?(key)
-            raise RuntimeError,
-                  "Parameter '#{key}' is missing in file '#{filename}'. " \
-                  "Set allow_missing: true to ignore missing parameters."
-          end
+      ##
+      # Initializes parameters of this block and its children.
+      # Equivalent to `self.collect_params.init(...)`.
+      #
+      # ====Parameters
+      #
+      # +init+::         (Initializer, default +nil+)
+      #                  The initializer to use.
+      # +ctx+::          (Context or array of Contexts, default +nil+)
+      #                  Desired contexts.
+      # +force_reinit+:: (boolean, default false)
+      #                  Whether to force re-initialization if parameter
+      #                  is already initialized.
+      #
+      def init(init: nil, ctx: nil, force_reinit: false)
+        collect_params.init(init: init, ctx: ctx, force_reinit: force_reinit)
+      end
+
+      ##
+      # Returns a ParameterDict containing this Block's and all of its
+      # children's Parameters. Also can return the Parameters that match
+      # some given regular expressions.
+      #
+      # For example, collect the specified Parameters for
+      # 'conv1_weight', 'conv1_bias', 'fc_weight' and 'fc_bias':
+      #
+      #     model.collect_params('conv1_weight|conv1_bias|fc_weight|fc_bias')
+      #
+      # or, alternatively, collect all parameters whose names end with
+      # 'weight' or 'bias':
+      #
+      #     model.collect_params('.*weight|.*bias')
+      #
+      # ====Parameters
+      #
+      # +select+:: (regexp) Regular expressions to match Parameters.
+      #
+      # ====Returns
+      #
+      # The filtered ParameterDict.
+      #
+      def collect_params(select = nil)
+        ret = ParameterDict.new(prefix: @params.prefix)
+        if select
+          ret.update(@params.select { |k, v| k =~ select })
+        else
+          ret.update(@params)
         end
-      end
-      unless ignore_extra
-        loaded.each do |key, value|
-          unless params.has_key?(key)
-            raise RuntimeError,
-                  "Parameter '#{key}' loaded from file '#{filename}' is " \
-                  "not present in this block. Set ignore_extra: true to " \
-                  "ignore extra parameters."
-          end
+        @reg_children.each do |_, child|
+          ret.update(child.collect_params(select))
         end
+        ret
       end
-      params.each do |key, value|
+
+      ##
+      # Saves parameters to file.
+      #
+      # Note that this method only saves parameters, not model
+      # structure. If you want to save model structures, use
+      # HybridBlock#export.
+      #
+      # For reference see: "Saving and Loading Gluon Models"
+      # (https://mxnet.incubator.apache.org/tutorials/gluon/save_load_params.html).
+      #
+      # ====Parameters
+      #
+      # +filename+:: (string)
+      #              Path to file.
+      #
+      def save_parameters(filename)
         # NOTE: invoking private method on Parameter
-        params[key].send(:load_and_init, ctx, loaded[key])
+        params = collect_params_for_storage.transform_values { |p| p.send(:reduce) }
+        MXNet::NDArray.save(filename, params)
       end
-    end
 
-    ##
-    # Registers block as a child of self. Blocks assigned as
-    # attributes will be registered automatically.
-    #
-    def register_child(block, name = nil)
-      name = @reg_children.length.to_s if name.nil?
-      @reg_children[name] = block
-    end
-
-    ##
-    # Activates or deactivates HybridBlock children recursively. Has
-    # no effect on non-hybrid children.
-    #
-    # ====Parameters
-    #
-    # +active+:: (boolean, default +true+)
-    #            Whether to turn hybridization on or off.
-    #
-    def hybridize(active: true, **kwargs)
-      @reg_children.each do |_, child|
-        child.hybridize(active: active, **kwargs)
-      end
-    end
-
-    ##
-    # Calls #forward. Only accepts positional arguments.
-    #
-    #
-    def [](*args)
-      forward(*args)
-    end
-
-    ##
-    # Override to implement forward computation using NDArray. Only
-    # accepts positional arguments.
-    #
-    # ====Parameters
-    #
-    # +args+:: (array of NDArray) Input tensors.
-    #
-    def forward(*args)
-      raise NotImplementedError
-    end
-
-    protected
-
-    def collect_params_for_storage(prefix = '')
-      prefix += '.' unless prefix.empty?
-      {}.tap do |hash|
-        @reg_parameters.each do |key, param|
-          hash[prefix + key] = param
-        end
-        @reg_children.each do |key, child|
-          hash.merge!(child.collect_params_for_storage(prefix + key))
-        end
-      end
-    end
-
-    private
-
-    def method_missing(sym, *args)
-      name = sym.to_s
-      if name[-1] == '='
-        args.length == 1 or
-          raise ArgumentError, "wrong number of arguments (#{args.length} for 1) to `#{sym}'"
-        set_attr(name[0...-1], *args)
-      else
-        args.length == 0 or
-          raise ArgumentError, "wrong number of arguments (#{args.length} for 0) to `#{sym}'"
-        get_attr(name)
-      end
-    end
-
-    def set_attr(name, value)
-      case value
-      when MXNet::Gluon::Block
-        register_child(value, name)
-      when MXNet::Gluon::Parameter
-        @reg_parameters[name] = value
-      else
-        @reg_other[name] = value
-      end
-    end
-
-    def get_attr(name)
-      [@reg_children, @reg_parameters, @reg_other].each do |h|
-        return h[name] if h.has_key?(name)
-      end
-      raise NoMethodError, "undefined method `#{name}' for #{self}"
-    end
-
-    def hint
-      self.class.name.split('::').last.downcase
-    end
-  end
-
-  ##
-  # CachedGraph encapsulates caching symbolized operations.
-  #
-  module CachedGraph
-    def initialize(**kwargs)
-      super(**kwargs)
-      clear_cache
-    end
-
-    def clear_cache
-      @cached_graph = nil
-      @cached_op = nil
-      @flags = {}
-    end
-
-    def infer_type(*args)
-      infer_attrs('infer_type', 'dtype', *args)
-    end
-
-    def infer_shape(*args)
-      infer_attrs('infer_shape', 'shape', *args)
-    end
-
-    protected
-
-    def call_cached(*args)
-      inputs, _, cached_op = get_cached_op(*args)
-      begin
-        data = inputs.map(&:data)
-        cached_op.call(*(args + data))
-      rescue MXNet::Gluon::DeferredInitializationError
-        infer_shape(*args)
-        inputs.each do |input|
-          # NOTE: invoking private method on Parameter
-          input.send(:finish_deferred_init)
-        end
-        retry
-      end
-    end
-
-    private
-
-    ##
-    # Infer attributes (type and shape).
-    #
-    def infer_attrs(fn, attr, *args)
-      inputs, output = get_graph(*args)
-      arg_attrs, _, aux_attrs =
-        output.send(fn, inputs.zip(args).inject({}) { |a, (i, j)| a[i.name] = j.send(attr) ; a })
-      sdict = output.list_arguments.zip(arg_attrs).to_h
-                .merge(output.list_auxiliary_states.zip(aux_attrs).to_h)
-      collect_params.values.each do |value|
-        value.send("#{attr}=", sdict[value.name.to_sym])
-      end
-    end
-
-    def get_graph(*args)
-      @cached_graph ||=
-        begin
-          inputs = (0...args.length).map do |i|
-            MXNet::Symbol.var("data#{i}")
+      ##
+      # Loads parameters from file.
+      #
+      # For reference see: "Saving and Loading Gluon Models"
+      # (https://mxnet.incubator.apache.org/tutorials/gluon/save_load_params.html).
+      #
+      # ====Parameters
+      #
+      # +filename+::      (string)
+      #                   Path to file.
+      # +ctx+::           (Context or array of Context, default cpu)
+      #                   Context(s) to initialize loaded parameters on.
+      # +allow_missing+:: (boolean, default +false+)
+      #                   Whether to silently skip parameters not
+      #                   present in the file.
+      # +ignore_extra+::  (boolean, default +false+)
+      #                   Whether to silently ignore parameters not
+      #                   present in this block.
+      #
+      def load_parameters(filename, ctx = MXNet.cpu,
+                          allow_missing: false,
+                          ignore_extra: false)
+        params = collect_params_for_storage
+        loaded = MXNet::NDArray.load(filename)
+        unless allow_missing
+          params.each do |key, value|
+            unless loaded.has_key?(key)
+              raise RuntimeError,
+                    "Parameter '#{key}' is missing in file '#{filename}'. " \
+                    "Set allow_missing: true to ignore missing parameters."
+            end
           end
-          params = @reg_parameters.inject({}) do |acc, (i, j)|
+        end
+        unless ignore_extra
+          loaded.each do |key, value|
+            unless params.has_key?(key)
+              raise RuntimeError,
+                    "Parameter '#{key}' loaded from file '#{filename}' is " \
+                    "not present in this block. Set ignore_extra: true to " \
+                    "ignore extra parameters."
+            end
+          end
+        end
+        params.each do |key, value|
+          # NOTE: invoking private method on Parameter
+          params[key].send(:load_and_init, ctx, loaded[key])
+        end
+      end
+
+      ##
+      # Registers block as a child of self. Blocks assigned as
+      # attributes will be registered automatically.
+      #
+      def register_child(block, name = nil)
+        name = @reg_children.length.to_s if name.nil?
+        @reg_children[name] = block
+      end
+
+      ##
+      # Activates or deactivates HybridBlock children recursively. Has
+      # no effect on non-hybrid children.
+      #
+      # ====Parameters
+      #
+      # +active+:: (boolean, default +true+)
+      #            Whether to turn hybridization on or off.
+      #
+      def hybridize(active: true, **kwargs)
+        @reg_children.each do |_, child|
+          child.hybridize(active: active, **kwargs)
+        end
+      end
+
+      ##
+      # Calls #forward. Only accepts positional arguments.
+      #
+      #
+      def [](*args)
+        forward(*args)
+      end
+
+      ##
+      # Override to implement forward computation using NDArray. Only
+      # accepts positional arguments.
+      #
+      # ====Parameters
+      #
+      # +args+:: (array of NDArray) Input tensors.
+      #
+      def forward(*args)
+        raise NotImplementedError
+      end
+
+      protected
+
+      def collect_params_for_storage(prefix = '')
+        prefix += '.' unless prefix.empty?
+        {}.tap do |hash|
+          @reg_parameters.each do |key, param|
+            hash[prefix + key] = param
+          end
+          @reg_children.each do |key, child|
+            hash.merge!(child.collect_params_for_storage(prefix + key))
+          end
+        end
+      end
+
+      private
+
+      def method_missing(sym, *args)
+        name = sym.to_s
+        if name[-1] == '='
+          args.length == 1 or
+            raise ArgumentError, "wrong number of arguments (#{args.length} for 1) to `#{sym}'"
+          set_attr(name[0...-1], *args)
+        else
+          args.length == 0 or
+            raise ArgumentError, "wrong number of arguments (#{args.length} for 0) to `#{sym}'"
+          get_attr(name)
+        end
+      end
+
+      def set_attr(name, value)
+        case value
+        when MXNet::Gluon::Block
+          register_child(value, name)
+        when MXNet::Gluon::Parameter
+          @reg_parameters[name] = value
+        else
+          @reg_other[name] = value
+        end
+      end
+
+      def get_attr(name)
+        [@reg_children, @reg_parameters, @reg_other].each do |h|
+          return h[name] if h.has_key?(name)
+        end
+        raise NoMethodError, "undefined method `#{name}' for #{self}"
+      end
+
+      def hint
+        self.class.name.split('::').last.downcase
+      end
+    end
+
+    ##
+    # CachedGraph encapsulates caching symbolized operations.
+    #
+    module CachedGraph
+      def initialize(**kwargs)
+        super(**kwargs)
+        clear_cache
+      end
+
+      def clear_cache
+        @cached_graph = nil
+        @cached_op = nil
+        @flags = {}
+      end
+
+      def infer_type(*args)
+        infer_attrs('infer_type', 'dtype', *args)
+      end
+
+      def infer_shape(*args)
+        infer_attrs('infer_shape', 'shape', *args)
+      end
+
+      protected
+
+      def call_cached(*args)
+        inputs, _, cached_op = get_cached_op(*args)
+        begin
+          data = inputs.map(&:data)
+          cached_op.call(*(args + data))
+        rescue MXNet::Gluon::DeferredInitializationError
+          infer_shape(*args)
+          inputs.each do |input|
+            # NOTE: invoking private method on Parameter
+            input.send(:finish_deferred_init)
+          end
+          retry
+        end
+      end
+
+      private
+
+      ##
+      # Infer attributes (type and shape).
+      #
+      def infer_attrs(fn, attr, *args)
+        inputs, output = get_graph(*args)
+        arg_attrs, _, aux_attrs =
+                      output.send(fn, inputs.zip(args).inject({}) { |a, (i, j)| a[i.name] = j.send(attr) ; a })
+        sdict = output.list_arguments.zip(arg_attrs).to_h
+                  .merge(output.list_auxiliary_states.zip(aux_attrs).to_h)
+        collect_params.values.each do |value|
+          value.send("#{attr}=", sdict[value.name.to_sym])
+        end
+      end
+
+      def get_graph(*args)
+        @cached_graph ||=
+          begin
+            inputs = (0...args.length).map do |i|
+              MXNet::Symbol.var("data#{i}")
+            end
+            params = @reg_parameters.inject({}) do |acc, (i, j)|
+              acc[i.to_sym] = j.var
+              acc
+            end
+            [inputs, hybrid_forward(MXNet::Symbol, *inputs, **params)]
+          end
+      end
+
+      def get_cached_op(*args)
+        @cached_op ||=
+          begin
+            _, output = get_graph(*args)
+            inputs = collect_params.values
+            [inputs, output, MXNet::CachedOp.new(output, @flags)]
+          end
+      end
+    end
+
+    ##
+    # HybridBlock supports forwarding with both Symbol and NDArray.
+    #
+    class HybridBlock < Block
+      include CachedGraph
+
+      def initialize(**kwargs)
+        super(**kwargs)
+        @active = false
+      end
+
+      def register_child(block, name = nil)
+        unless block.is_a?(MXNet::Gluon::HybridBlock)
+          raise RuntimeError,
+                "Children of a HybridBlock must also be a HybridBlock, " \
+                "but #{block} has type #{block.class}. If you are using " \
+                "Sequential, please try HybridSequential instead."
+        end
+        clear_cache
+        super
+      end
+
+      def set_attr(name, value)
+        clear_cache if value.is_a?(HybridBlock)
+        super
+      end
+
+      def hybridize(active: true, **kwargs)
+        clear_cache
+        @active = active
+        @flags = kwargs
+        super
+      end
+
+      ##
+      # Exports HybridBlock to JSON format that can be loaded by
+      # SymbolBlock.import.
+      #
+      # ====Parameters
+      #
+      # +filename+:: (string)
+      #              Path and base filename to which to save
+      #              model. Two files, "[filename]-symbol.json" and
+      #              "[filename]-NNNN.params" will be created, where
+      #              +NNNN+ is the 4 digit epoch number.
+      # +epoch+::    (integer, default +0+)
+      #              Epoch number of saved model.
+      #
+      def export(filename, epoch: 0)
+        unless @cached_graph
+          raise RuntimeError,
+                "Please call hybridize and then run forward " \
+                "at least once before calling export."
+        end
+        output = @cached_graph[1]
+        output.save('%s-symbol.json' % filename)
+        arg_names = output.list_arguments
+        aux_names = output.list_auxiliary_states
+        args = {}
+        collect_params.each do |name, param|
+          # NOTE: invoking private method on Parameter
+          if arg_names.include?(name.to_sym)
+            args["arg:#{name}"] = param.send(:reduce)
+          elsif aux_names.include?(name.to_sym)
+            args["aux:#{name}"] = param.send(:reduce)
+          end
+        end
+        MXNet::NDArray.save('%s-%04d.params' % [filename, epoch], args)
+      end
+
+      ##
+      # Defines the forward computation. Arguments can be either Symbol
+      # or NDArray.
+      #
+      # ====Parameters
+      #
+      # +args+:: (array of Symbol or NDArray) Input tensors.
+      #
+      def forward(*args)
+        case args.first
+        when MXNet::Symbol
+          kwargs = @reg_parameters.inject({}) do |acc, (i, j)|
             acc[i.to_sym] = j.var
             acc
           end
-          [inputs, hybrid_forward(MXNet::Symbol, *inputs, **params)]
-        end
-    end
-
-    def get_cached_op(*args)
-      @cached_op ||=
-        begin
-          _, output = get_graph(*args)
-          inputs = collect_params.values
-          [inputs, output, MXNet::CachedOp.new(output, @flags)]
-        end
-    end
-  end
-
-  ##
-  # HybridBlock supports forwarding with both Symbol and NDArray.
-  #
-  class HybridBlock < Block
-    include CachedGraph
-
-    def initialize(**kwargs)
-      super(**kwargs)
-      @active = false
-    end
-
-    def register_child(block, name = nil)
-      unless block.is_a?(MXNet::Gluon::HybridBlock)
-        raise RuntimeError,
-              "Children of a HybridBlock must also be a HybridBlock, " \
-              "but #{block} has type #{block.class}. If you are using " \
-              "Sequential, please try HybridSequential instead."
-      end
-      clear_cache
-      super
-    end
-
-    def set_attr(name, value)
-      clear_cache if value.is_a?(HybridBlock)
-      super
-    end
-
-    def hybridize(active: true, **kwargs)
-      clear_cache
-      @active = active
-      @flags = kwargs
-      super
-    end
-
-    ##
-    # Exports HybridBlock to JSON format that can be loaded by
-    # SymbolBlock.import.
-    #
-    # ====Parameters
-    #
-    # +filename+:: (string)
-    #              Path and base filename to which to save
-    #              model. Two files, "[filename]-symbol.json" and
-    #              "[filename]-NNNN.params" will be created, where
-    #              +NNNN+ is the 4 digit epoch number.
-    # +epoch+::    (integer, default +0+)
-    #              Epoch number of saved model.
-    #
-    def export(filename, epoch: 0)
-      unless @cached_graph
-        raise RuntimeError,
-              "Please call hybridize and then run forward " \
-              "at least once before calling export."
-      end
-      output = @cached_graph[1]
-      output.save('%s-symbol.json' % filename)
-      arg_names = output.list_arguments
-      aux_names = output.list_auxiliary_states
-      args = {}
-      collect_params.each do |name, param|
-        # NOTE: invoking private method on Parameter
-        if arg_names.include?(name.to_sym)
-          args["arg:#{name}"] = param.send(:reduce)
-        elsif aux_names.include?(name.to_sym)
-          args["aux:#{name}"] = param.send(:reduce)
-        end
-      end
-      MXNet::NDArray.save('%s-%04d.params' % [filename, epoch], args)
-    end
-
-    ##
-    # Defines the forward computation. Arguments can be either Symbol
-    # or NDArray.
-    #
-    # ====Parameters
-    #
-    # +args+:: (array of Symbol or NDArray) Input tensors.
-    #
-    def forward(*args)
-      case args.first
-      when MXNet::Symbol
-        kwargs = @reg_parameters.inject({}) do |acc, (i, j)|
-          acc[i.to_sym] = j.var
-          acc
-        end
-        hybrid_forward(MXNet::Symbol, *args, **kwargs)
-      when MXNet::NDArray
-        if @active
-          return call_cached(*args)
-        end
-        MXNet::Context.with(ctx = args.first.context) do
-          begin
-            kwargs = @reg_parameters.inject({}) do |acc, (i, j)|
-              acc[i.to_sym] = j.data(ctx: ctx)
-              acc
+          hybrid_forward(MXNet::Symbol, *args, **kwargs)
+        when MXNet::NDArray
+          if @active
+            return call_cached(*args)
+          end
+          MXNet::Context.with(ctx = args.first.context) do
+            begin
+              kwargs = @reg_parameters.inject({}) do |acc, (i, j)|
+                acc[i.to_sym] = j.data(ctx: ctx)
+                acc
+              end
+            rescue MXNet::Gluon::DeferredInitializationError
+              infer_shape(*args)
+              @params.each do |_, param|
+                # NOTE: invoking private method on Parameter
+                param.send(:finish_deferred_init)
+              end
+              retry
             end
-          rescue MXNet::Gluon::DeferredInitializationError
-            infer_shape(*args)
-            @params.each do |_, param|
+            hybrid_forward(MXNet::NDArray, *args, **kwargs)
+          end
+        else
+          raise ArgumentError,
+                "only Symbol or NDArray are supported, " \
+                "not #{args.first.class}"
+        end
+      end
+
+      ##
+      # Override to construct symbolic graph for this Block.
+      #
+      # ====Parameters
+      #
+      # +args+:: (array of NDArray or Symbol) Input tensors.
+      #
+      #
+      def hybrid_forward(clazz, *args)
+        raise NotImplementedError
+      end
+    end
+
+    ##
+    # A block constructed from a Symbol.
+    #
+    class SymbolBlock < MXNet::Gluon::Block
+      include CachedGraph
+
+      ##
+      # Imports model previously saved to JSON format by
+      # HybridBlock#export as a SymbolBlock for use in Gluon.
+      #
+      # ====Parameters
+      #
+      # +filename+:: (string)
+      #              Path and base filename from which to load
+      #              model. Two files, "[filename]-symbol.json" and
+      #              "[filename]-NNNN.params" will be loaded, where
+      #              +NNNN+ is the 4 digit epoch number.
+      # +inputs+::   (string or array of strings)
+      #              Input names.
+      # +epoch+::    (integer, default +0+)
+      #              Epoch number of saved model.
+      # +ctx+::      (Context or array of Context, default cpu)
+      #              Context(s) to initialize loaded parameters on.
+      #
+      def self.import(filename, inputs, epoch: 0, ctx: MXNet.cpu,
+                      allow_missing: false,
+                      ignore_extra: false)
+        output = MXNet::Symbol.load('%s-symbol.json' % filename)
+        inputs = [inputs] unless inputs.is_a?(Array)
+        inputs = inputs.map { |i| MXNet::Symbol.var(i) }
+        SymbolBlock.new(output, inputs).tap do |block|
+          if epoch
+            filename = '%s-%04d.params' % [filename, epoch]
+            arg_dict = MXNet::NDArray.load(filename)
+            arg_dict = arg_dict.transform_keys { |k| k.gsub(/^(arg:|aux:)/, '') }
+            unless allow_missing
+              block.params.keys.each do |key|
+                unless arg_dict.has_key?(key.to_s)
+                  raise RuntimeError,
+                        "Parameter '#{key}' is missing in file '#{filename}'. " \
+                        "Set allow_missing: true to ignore missing parameters."
+                end
+              end
+            end
+            unless ignore_extra
+              arg_dict.keys.each do |key|
+                unless block.params.keys.include?(key.to_sym)
+                  raise RuntimeError,
+                        "Parameter '#{key}' loaded from file '#{filename}' is " \
+                        "not present in this block. Set ignore_extra: true to " \
+                        "ignore extra parameters."
+                end
+              end
+            end
+            arg_dict.each do |key, value|
+              param = block.params.get(key)
+              param.shape = value.shape
               # NOTE: invoking private method on Parameter
-              param.send(:finish_deferred_init)
-            end
-            retry
-          end
-          hybrid_forward(MXNet::NDArray, *args, **kwargs)
-        end
-      else
-        raise ArgumentError,
-              "only Symbol or NDArray are supported, " \
-              "not #{args.first.class}"
-      end
-    end
-
-    ##
-    # Override to construct symbolic graph for this Block.
-    #
-    # ====Parameters
-    #
-    # +args+:: (array of NDArray or Symbol) Input tensors.
-    #
-    #
-    def hybrid_forward(clazz, *args)
-      raise NotImplementedError
-    end
-  end
-
-  ##
-  # A block constructed from a Symbol.
-  #
-  class SymbolBlock < MXNet::Gluon::Block
-    include CachedGraph
-
-    ##
-    # Imports model previously saved to JSON format by
-    # HybridBlock#export as a SymbolBlock for use in Gluon.
-    #
-    # ====Parameters
-    #
-    # +filename+:: (string)
-    #              Path and base filename from which to load
-    #              model. Two files, "[filename]-symbol.json" and
-    #              "[filename]-NNNN.params" will be loaded, where
-    #              +NNNN+ is the 4 digit epoch number.
-    # +inputs+::   (string or array of strings)
-    #              Input names.
-    # +epoch+::    (integer, default +0+)
-    #              Epoch number of saved model.
-    # +ctx+::      (Context or array of Context, default cpu)
-    #              Context(s) to initialize loaded parameters on.
-    #
-    def self.import(filename, inputs, epoch: 0, ctx: MXNet.cpu,
-                    allow_missing: false,
-                    ignore_extra: false)
-      output = MXNet::Symbol.load('%s-symbol.json' % filename)
-      inputs = [inputs] unless inputs.is_a?(Array)
-      inputs = inputs.map { |i| MXNet::Symbol.var(i) }
-      SymbolBlock.new(output, inputs).tap do |block|
-        if epoch
-          filename = '%s-%04d.params' % [filename, epoch]
-          arg_dict = MXNet::NDArray.load(filename)
-          arg_dict = arg_dict.transform_keys { |k| k.gsub(/^(arg:|aux:)/, '') }
-          unless allow_missing
-            block.params.keys.each do |key|
-              unless arg_dict.has_key?(key.to_s)
-                raise RuntimeError,
-                      "Parameter '#{key}' is missing in file '#{filename}'. " \
-                      "Set allow_missing: true to ignore missing parameters."
-              end
+              param.send(:load_and_init, ctx, value)
             end
           end
-          unless ignore_extra
-            arg_dict.keys.each do |key|
-              unless block.params.keys.include?(key.to_sym)
-                raise RuntimeError,
-                      "Parameter '#{key}' loaded from file '#{filename}' is " \
-                      "not present in this block. Set ignore_extra: true to " \
-                      "ignore extra parameters."
-              end
-            end
-          end
-          arg_dict.each do |key, value|
-            param = block.params.get(key)
-            param.shape = value.shape
-            # NOTE: invoking private method on Parameter
-            param.send(:load_and_init, ctx, value)
-          end
         end
       end
-    end
 
-    ##
-    # Creates a new instance.
-    #
-    # =====Parameters
-    #
-    # +output+:: (Symbol)
-    #            The output.
-    # +inputs+:: (array of Symbols)
-    #            The output's arguments that should be used as inputs.
-    # +params+:: (ParameterDict, default: +nil+)
-    #            Dict of arguments and auxiliary states that are not
-    #            inputs.
-    #
-    def initialize(output, inputs, params: nil)
-      super(
-        prefix: '',
-        params: MXNet::Gluon::ParameterDict.new(prefix: '', shared: params)
-      )
-      input_names = inputs.map { |i| i.name.to_sym }
-      output.list_arguments.each do |i|
-        unless input_names.include?(i)
-          self.params.get(i.to_s, allow_deferred_init: true)
+      ##
+      # Creates a new instance.
+      #
+      # =====Parameters
+      #
+      # +output+:: (Symbol)
+      #            The output.
+      # +inputs+:: (array of Symbols)
+      #            The output's arguments that should be used as inputs.
+      # +params+:: (ParameterDict, default: +nil+)
+      #            Dict of arguments and auxiliary states that are not
+      #            inputs.
+      #
+      def initialize(output, inputs, params: nil)
+        super(
+          prefix: '',
+          params: MXNet::Gluon::ParameterDict.new(prefix: '', shared: params)
+        )
+        input_names = inputs.map { |i| i.name.to_sym }
+        output.list_arguments.each do |i|
+          unless input_names.include?(i)
+            self.params.get(i.to_s, allow_deferred_init: true)
+          end
         end
-      end
-      output.list_auxiliary_states.each do |i|
-        unless input_names.include?(i)
-          self.params.get(i.to_s, allow_deferred_init: true, grad_req: :null)
+        output.list_auxiliary_states.each do |i|
+          unless input_names.include?(i)
+            self.params.get(i.to_s, allow_deferred_init: true, grad_req: :null)
+          end
         end
-      end
-      @cached_graph = [inputs, output]
-      len = lcp(@params.keys).length
-      @reg_parameters =
-        @params.inject({}) do |acc, (name, param)|
+        @cached_graph = [inputs, output]
+        len = lcp(@params.keys).length
+        @reg_parameters =
+          @params.inject({}) do |acc, (name, param)|
           acc[name[len..-1]] = param
           acc
         end
-    end
+      end
 
-    def forward(*args)
-      case args.first
-      when MXNet::Symbol
-        @cached_graph[1].dup.tap do |output|
-          kwargs = @cached_graph[0].zip(args).map { |k, v| [k.name, v] }.to_h
-          # NOTE: invoking private method on Symbol
-          output.send(:compose, **kwargs)
+      def forward(*args)
+        case args.first
+        when MXNet::Symbol
+          @cached_graph[1].dup.tap do |output|
+            kwargs = @cached_graph[0].zip(args).map { |k, v| [k.name, v] }.to_h
+            # NOTE: invoking private method on Symbol
+            output.send(:compose, **kwargs)
+          end
+        when MXNet::NDArray
+          MXNet::Context.with(ctx = args.first.context) do
+            self.call_cached(*args)
+          end
+        else
+          raise ArgumentError,
+                "only Symbol or NDArray are supported, " \
+                "not #{args.first.class}"
         end
-      when MXNet::NDArray
-        MXNet::Context.with(ctx = args.first.context) do
-          self.call_cached(*args)
+      end
+
+      private
+
+      ##
+      # Gets the longest common prefix of names.
+      #
+      def lcp(names)
+        case names.length
+        when 0, 1
+          names.first || ''
+        else
+          min, max = names.minmax
+          i = min.length.times{ |i| break i if min[i] != max[i] }
+          min[0...i]
         end
-      else
-        raise ArgumentError,
-              "only Symbol or NDArray are supported, " \
-              "not #{args.first.class}"
       end
     end
 
-    private
-
-    ##
-    # Gets the longest common prefix of names.
-    #
-    def lcp(names)
-      case names.length
-      when 0, 1
-        names.first || ''
-      else
-        min, max = names.minmax
-        i = min.length.times{ |i| break i if min[i] != max[i] }
-        min[0...i]
-      end
+    def self.SymbolBlock(*args)
+      SymbolBlock.new(*args)
     end
-  end
-
-  def self.SymbolBlock(*args)
-    SymbolBlock.new(*args)
   end
 end

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -416,9 +416,14 @@ module MXNet
       def get_graph(*args)
         @cached_graph ||=
           begin
-            inputs = (0...args.length).map do |i|
-              MXNet::Symbol.var("data#{i}")
-            end
+            inputs =
+              if args.length > 1
+                (0...args.length).map do |i|
+                  MXNet::Symbol.var("data#{i}")
+                end
+              else
+                [MXNet::Symbol.var('data')]
+              end
             params = @reg_parameters.inject({}) do |acc, (i, j)|
               acc[i.to_sym] = j.var
               acc

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -89,8 +89,8 @@ module MXNet::Gluon
       raise NotImplementedError
     end
     private
-    def method_missing(name, value = nil)
-      name = name.to_s
+    def method_missing(sym, value = nil)
+      name = sym.to_s
       if name[-1] == '='
         name = name[0...-1]
         case value
@@ -98,11 +98,12 @@ module MXNet::Gluon
         when MXNet::Gluon::Parameter
           @reg_parameters[name] = value
         else
-          raise NoMethodError
+          raise TypeError, "value must be either " \
+                           "MXNet::Gluon::Block or " \
+                           "MXNet::Gluon::Parameter"
         end
       else
-        @reg_parameters[name] or
-          raise NoMethodError
+        @reg_parameters[name] or super
       end
     end
     def hint

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -239,7 +239,7 @@ module MXNet
         loaded = MXNet::NDArray.load(filename)
         unless allow_missing
           params.each do |key, value|
-            unless loaded.has_key?(key)
+            unless loaded.key?(key)
               raise RuntimeError,
                     "Parameter '#{key}' is missing in file '#{filename}'. " \
                     "Set allow_missing: true to ignore missing parameters."
@@ -248,7 +248,7 @@ module MXNet
         end
         unless ignore_extra
           loaded.each do |key, value|
-            unless params.has_key?(key)
+            unless params.key?(key)
               raise RuntimeError,
                     "Parameter '#{key}' loaded from file '#{filename}' is " \
                     "not present in this block. Set ignore_extra: true to " \
@@ -289,8 +289,7 @@ module MXNet
       ##
       # Calls #forward. Only accepts positional arguments.
       #
-      #
-      def [](*args)
+      def call(*args)
         forward(*args)
       end
 
@@ -348,7 +347,7 @@ module MXNet
 
       def get_attr(name)
         [@reg_children, @reg_parameters, @reg_other].each do |h|
-          return h[name] if h.has_key?(name)
+          return h[name] if h.key?(name)
         end
         raise NoMethodError, "undefined method `#{name}' for #{self}"
       end
@@ -601,7 +600,7 @@ module MXNet
             arg_dict = arg_dict.transform_keys { |k| k.gsub(/^(arg:|aux:)/, '') }
             unless allow_missing
               block.params.keys.each do |key|
-                unless arg_dict.has_key?(key.to_s)
+                unless arg_dict.key?(key.to_s)
                   raise RuntimeError,
                         "Parameter '#{key}' is missing in file '#{filename}'. " \
                         "Set allow_missing: true to ignore missing parameters."
@@ -610,7 +609,7 @@ module MXNet
             end
             unless ignore_extra
               arg_dict.keys.each do |key|
-                unless block.params.keys.include?(key.to_sym)
+                unless block.params.key?(key.to_sym)
                   raise RuntimeError,
                         "Parameter '#{key}' loaded from file '#{filename}' is " \
                         "not present in this block. Set ignore_extra: true to " \
@@ -675,7 +674,7 @@ module MXNet
             output.send(:compose, **kwargs)
           end
         when MXNet::NDArray
-          MXNet::Context.with(ctx = args.first.context) do
+          MXNet::Context.with(args.first.context) do
             self.call_cached(*args)
           end
         else

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -227,11 +227,16 @@ module MXNet::Gluon
     def hybrid_forward(clazz, *args)
       raise NotImplementedError
     end
-    private
-    def deferred_infer_shape(*args)
-      # FIXME: for now, punt to the subclass
-      raise NotImplementedError
+    def infer_type(*args)
+      infer_attrs('infer_type', 'dtype', *args)
     end
+    def infer_shape(*args)
+      infer_attrs('infer_shape', 'shape', *args)
+    end
+    def deferred_infer_shape(*args)
+      infer_shape(*args)
+    end
+    private
     def get_graph(*args)
       @cached_graph ||=
         begin
@@ -247,6 +252,19 @@ module MXNet::Gluon
     end
     def clear_cache
       @cached_graph = nil
+    end
+    ##
+    # Infer attributes.
+    #
+    def infer_attrs(fn, attr, *args)
+      inputs, output = get_graph(*args)
+      arg_attrs, _, aux_attrs =
+        output.send(fn, inputs.zip(args).inject({}) { |a, (i, j)| a[i.name] = j.send(attr) ; a })
+      sdict = output.list_arguments.zip(arg_attrs).to_h
+                .merge(output.list_auxiliary_states.zip(aux_attrs).to_h)
+      collect_params.values.each do |value|
+        value.send("#{attr}=", sdict[value.name.to_sym])
+      end
     end
   end
 end

--- a/lib/mxnet/gluon/block.rb
+++ b/lib/mxnet/gluon/block.rb
@@ -364,6 +364,41 @@ module MXNet::Gluon
       super
     end
     ##
+    # Exports HybridBlock to JSON format that can be loaded by
+    # SymbolBlock.import.
+    #
+    # ====Parameters
+    #
+    # +filename+:: (string)
+    #              Path and base filename to which to save
+    #              model. Two files, "[filename]-symbol.json" and
+    #              "[filename]-NNNN.params" will be created, where
+    #              +NNNN+ is the 4 digit epoch number.
+    # +epoch+::    (integer, default +0+)
+    #              Epoch number of saved model.
+    #
+    def export(filename, epoch: 0)
+      unless @cached_graph
+        raise RuntimeError,
+              "Please call hybridize and then run forward " \
+              "at least once before calling export."
+      end
+      output = @cached_graph[1]
+      output.save('%s-symbol.json' % filename)
+      arg_names = output.list_arguments
+      aux_names = output.list_auxiliary_states
+      args = {}
+      collect_params.each do |name, param|
+        # NOTE: invoking private method on Parameter
+        if arg_names.include?(name.to_sym)
+          args["arg:#{name}"] = param.send(:reduce)
+        elsif aux_names.include?(name.to_sym)
+          args["aux:#{name}"] = param.send(:reduce)
+        end
+      end
+      MXNet::NDArray.save('%s-%04d.params' % [filename, epoch], args)
+    end
+    ##
     # Defines the forward computation. Arguments can be either Symbol
     # or NDArray.
     #
@@ -484,6 +519,63 @@ module MXNet::Gluon
   # A block constructed from a Symbol.
   #
   class SymbolBlock < MXNet::Gluon::HybridBlock
+    ##
+    # Imports model previously saved to JSON format by
+    # HybridBlock#export as a SymbolBlock for use in Gluon.
+    #
+    # ====Parameters
+    #
+    # +filename+:: (string)
+    #              Path and base filename from which to load
+    #              model. Two files, "[filename]-symbol.json" and
+    #              "[filename]-NNNN.params" will be loaded, where
+    #              +NNNN+ is the 4 digit epoch number.
+    # +inputs+::   (string or array of strings)
+    #              Input names.
+    # +epoch+::    (integer, default +0+)
+    #              Epoch number of saved model.
+    # +ctx+::      (Context or array of Context, default cpu)
+    #              Context(s) to initialize loaded parameters on.
+    #
+    def self.import(filename, inputs, epoch: 0, ctx: MXNet.cpu,
+                    allow_missing: false,
+                    ignore_extra: false)
+      output = MXNet::Symbol.load('%s-symbol.json' % filename)
+      inputs = [inputs] unless inputs.is_a?(Array)
+      inputs = inputs.map { |i| MXNet::Symbol.var(i) }
+      SymbolBlock.new(output, inputs).tap do |block|
+        if epoch
+          filename = '%s-%04d.params' % [filename, epoch]
+          arg_dict = MXNet::NDArray.load(filename)
+          arg_dict = arg_dict.transform_keys { |k| k.gsub(/^(arg:|aux:)/, '') }
+          unless allow_missing
+            block.params.keys.each do |key|
+              unless arg_dict.has_key?(key.to_s)
+                raise RuntimeError,
+                      "Parameter '#{key}' is missing in file '#{filename}'. " \
+                      "Set allow_missing: true to ignore missing parameters."
+              end
+            end
+          end
+          unless ignore_extra
+            arg_dict.keys.each do |key|
+              unless block.params.keys.include?(key.to_sym)
+                raise RuntimeError,
+                      "Parameter '#{key}' loaded from file '#{filename}' is " \
+                      "not present in this block. Set ignore_extra: true to " \
+                      "ignore extra parameters."
+              end
+            end
+          end
+          arg_dict.each do |key, value|
+            param = block.params.get(key)
+            param.shape = value.shape
+            # NOTE: invoking private method on Parameter
+            param.send(:load_and_init, ctx, value)
+          end
+        end
+      end
+    end
     ##
     # Creates a new instance.
     #

--- a/lib/mxnet/gluon/data.rb
+++ b/lib/mxnet/gluon/data.rb
@@ -6,4 +6,6 @@ module MXNet
 end
 
 require_relative 'data/dataset'
+require_relative 'data/data_loader'
+require_relative 'data/sampler'
 require_relative 'data/vision/mnist'

--- a/lib/mxnet/gluon/data/data_loader.rb
+++ b/lib/mxnet/gluon/data/data_loader.rb
@@ -1,0 +1,81 @@
+require 'mxnet/gluon/data'
+require 'mxnet/gluon/data/sampler'
+
+module MXNet
+  module Gluon
+    module Data
+      ##
+      # Loads data from a Dataset and returns mini-batches of data.
+      #
+      class DataLoader
+        include Enumerable
+
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +dataset+::    (Dataset, NDArray or array)
+        #                Source. Note that instances of NDArray and
+        #                Array can be used directly.
+        # +shuffle+::    (boolean)
+        #                Whether or not to shuffle the samples.
+        # +batch_size+:: (integer)
+        #                Size of mini-batch.
+        # +last_batch+:: (+:keep+, +:discard+, +:rollover+)
+        #                Specifies how the last batch is handled if
+        #                +batch_size+ does not evenly divide sequence
+        #                length. If +:keep+, the last batch will be
+        #                returned directly, but will contain fewer
+        #                elements than +batch_size+ requires. If
+        #                +:discard+, the last batch will be discarded.
+        #                If +:rollover+, the remaining elements will
+        #                be rolled over to the next iteration.
+        #
+        def initialize(dataset, shuffle:, batch_size:, last_batch: :keep)
+          @dataset = dataset
+          @sampler = shuffle ?
+                       MXNet::Gluon::Data.RandomSampler(dataset.length) :
+                       MXNet::Gluon::Data.SequentialSampler(dataset.length)
+          @sampler = MXNet::Gluon::Data.BatchSampler(@sampler, batch_size, last_batch)
+        end
+
+        def length
+          @sampler.length
+        end
+
+        def each
+          return enum unless block_given?
+          enum.each do |i|
+            yield i
+          end
+        end
+
+        private
+
+        def enum
+          Enumerator.new do |yielder|
+            @sampler.each do |batch|
+              yielder << batchify(batch.map { |i| @dataset[i] })
+            end
+          end
+        end
+
+        def batchify(data)
+          case data[0]
+          when Array
+            data[0].zip(*data[1..-1]).map { |d| batchify(d) }
+          when MXNet::NDArray
+            MXNet::NDArray.stack(*data)
+          else
+            MXNet::NDArray.array(data.to_a)
+          end
+        end
+      end
+
+      def self.DataLoader(*args)
+        DataLoader.new(*args)
+      end
+    end
+  end
+end

--- a/lib/mxnet/gluon/data/dataset.rb
+++ b/lib/mxnet/gluon/data/dataset.rb
@@ -25,7 +25,7 @@ module MXNet::Gluon::Data
     def transform(lazy: true)
       trans = LazyTransformDataset.new(self, &proc)
       return trans if lazy
-      SimpleDataset.new(p trans.map.to_a)
+      SimpleDataset.new(trans.map.to_a)
     end
 
     def transform_first(lazy: true)

--- a/lib/mxnet/gluon/data/sampler.rb
+++ b/lib/mxnet/gluon/data/sampler.rb
@@ -1,0 +1,176 @@
+require 'mxnet/gluon/data'
+
+module MXNet
+  module Gluon
+    module Data
+      ##
+      # Base class for samplers.
+      #
+      # All samplers should subclass Sampler and define #length and
+      # #each methods.
+      #
+      class Sampler
+        include Enumerable
+
+        def length
+          raise NotImplementedError
+        end
+
+        def each
+          raise NotImplementedError
+        end
+      end
+
+      ##
+      # Samples elements from [0, length) sequentially.
+      #
+      class SequentialSampler < Sampler
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +length+:: (integer)
+        #            Length of the sequence.
+        #
+        def initialize(length)
+          @length = length
+        end
+
+        def length
+          @length
+        end
+
+        def each
+          enum = @length.times
+          return enum unless block_given?
+          enum.each do |i|
+            yield i
+          end
+        end
+      end
+
+      def self.SequentialSampler(*args)
+        SequentialSampler.new(*args)
+      end
+
+      ##
+      # Samples elements from [0, length) randomly without
+      # replacement.
+      #
+      class RandomSampler < Sampler
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +length+:: (integer)
+        #            Length of the sequence.
+        #
+        def initialize(length)
+          @length = length
+        end
+
+        def length
+          @length
+        end
+
+        def each
+          enum = @length.times.to_a.shuffle.each
+          return enum unless block_given?
+          enum.each do |i|
+            yield i
+          end
+        end
+      end
+
+      def self.RandomSampler(*args)
+        RandomSampler.new(*args)
+      end
+
+      ##
+      # Wraps another Sampler and return mini-batches of samples.
+      #
+      #     sampler = MXNet::Gluon::Data.SequentialSampler(10)
+      #     batch_sampler = MXNet::Gluon::Data.BatchSampler(sampler, 3, :keep)
+      #     batch_sampler.to_a # => [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
+      #
+      class BatchSampler < Sampler
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +sampler+::    (Sampler)
+        #                The source Sampler.
+        # +batch_size+:: (integer)
+        #                Size of mini-batch.
+        # +last_batch+:: (+:keep+, +:discard+, +:rollover+)
+        #                Specifies how the last batch is handled if
+        #                +batch_size+ does not evenly divide sequence
+        #                length. If +:keep+, the last batch will be
+        #                returned directly, but will contain fewer
+        #                elements than +batch_size+ requires. If
+        #                +:discard+, the last batch will be discarded.
+        #                If +:rollover+, the remaining elements will
+        #                be rolled over to the next iteration.
+        #
+        def initialize(sampler, batch_size, last_batch = :keep)
+          unless [:keep, :discard, :rollover].include?(last_batch)
+            raise ArgumentError, 'last_batch must be either :keep, :discard, or :rollover'
+          end
+          @sampler = sampler
+          @batch_size = batch_size
+          @last_batch = last_batch
+          @prev = []
+        end
+
+        def length
+          case @last_batch
+          when :discard
+            @sampler.length / @batch_size
+          when :keep
+            (@sampler.length + @batch_size - 1) / @batch_size
+          when :rollover
+            (@sampler.length + @prev.length) / @batch_size
+          end
+        end
+
+        def each
+          return enum unless block_given?
+          enum.each do |i|
+            yield i
+          end
+        end
+
+        private
+
+        def enum
+          Enumerator.new do |yielder|
+            batch, @prev = @prev, []
+            @sampler.each do |i|
+              batch << i
+              if batch.length == @batch_size
+                yielder << batch
+                batch = []
+              end
+            end
+            unless batch.empty?
+              case @last_batch
+              when :discard
+              when :keep
+                yielder << batch
+              when :rollover
+                @prev = batch
+              end
+            end
+          end
+        end
+      end
+
+      def self.BatchSampler(*args)
+        BatchSampler.new(*args)
+      end
+    end
+  end
+end

--- a/lib/mxnet/gluon/loss.rb
+++ b/lib/mxnet/gluon/loss.rb
@@ -1,0 +1,97 @@
+require 'mxnet/gluon/block'
+
+module MXNet::Gluon
+  ##
+  # Base class for loss.
+  #
+  class Loss < MXNet::Gluon::HybridBlock
+    def initialize(**kwargs)
+      super(**kwargs)
+    end
+    ##
+    # Override to construct symbolic graph for this Block.
+    #
+    # ====Parameters
+    #
+    # +args+:: (array of NDArray or Symbol) Input tensors.
+    #
+    #
+    def hybrid_forward(clazz, *args)
+      raise NotImplementedError
+    end
+    protected
+    ##
+    # Reshapes x to be the same shape as y.
+    #
+    def reshape_like(clazz, x, y)
+      case clazz
+      when MXNet::NDArray
+        x.reshape(y.shape)
+      else
+        clazz.reshape_like(x, y)
+      end
+    end
+    ##
+    # Apply weighting to loss.
+    #
+    # ====Parameters
+    #
+    # +loss+::          (Symbol or NDArray)
+    #                   The loss to be weighted.
+    # +weight+::        (float or +nil+)
+    #                   Global scalar weight for loss.
+    # +sample_weight+:: (Symbol, NDArray or +nil+)
+    #                   Per sample weighting. Must be broadcastable to
+    #                   the same shape as loss. For example, if loss
+    #                   has shape (64, 10) and you want to weight each
+    #                   sample in the batch separately, +sample_weight+
+    #                   should have shape (64, 1).
+    #
+    # ====Returns
+    #
+    # Weighted loss
+    #
+    #
+    def apply_weighting(clazz, loss, weight = nil, sample_weight = nil)
+      unless weight.nil?
+        raise ArgumentError, 'weight must be numeric' unless weight.is_a?(Numeric)
+        loss = loss * weight
+      end
+      unless sample_weight.nil?
+        loss = clazz.broadcast_mul(loss, sample_weight)
+      end
+      loss
+    end
+  end
+  ##
+  # Calculates the mean squared error between prediction and label.
+  #
+  # Inputs "prediction" and "label" can have arbitrary shape as long
+  # as they have the same number of elements.
+  #
+  class L2Loss < Loss
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +weight+::     (float or +nil+)
+    #                Global scalar weight for loss.
+    # +batch_axis+:: (integer, default 0)
+    #                The axis that represents mini-batch.
+    #
+    def initialize(weight: 1.0, batch_axis: 0, **kwargs)
+      super(**kwargs)
+      @weight = weight
+      @batch_axis = batch_axis
+    end
+    def hybrid_forward(clazz, prediction = nil, label = nil, sample_weight: nil, **kwargs)
+      prediction ||= kwargs[:prediction]
+      label ||= kwargs[:label]
+      label = reshape_like(clazz, label, prediction)
+      loss = clazz.square(prediction - label)
+      loss = apply_weighting(clazz, loss, @weight/2, sample_weight)
+      clazz.mean(loss, axis: @batch_axis, exclude: true)
+    end
+  end
+end

--- a/lib/mxnet/gluon/loss.rb
+++ b/lib/mxnet/gluon/loss.rb
@@ -21,6 +21,7 @@ module MXNet::Gluon
       @batch_axis = batch_axis
       super(**kwargs)
     end
+
     ##
     # Override to construct symbolic graph for this Block.
     #
@@ -32,37 +33,7 @@ module MXNet::Gluon
     def hybrid_forward(clazz, *args)
       raise NotImplementedError
     end
-    protected
-    ##
-    # Apply weighting to loss.
-    #
-    # ====Parameters
-    #
-    # +loss+::          (Symbol or NDArray)
-    #                   The loss to be weighted.
-    # +weight+::        (float or +nil+)
-    #                   Global scalar weight for loss.
-    # +sample_weight+:: (Symbol, NDArray or +nil+)
-    #                   Per sample weighting. Must be broadcastable to
-    #                   the same shape as loss. For example, if loss
-    #                   has shape (64, 10) and you want to weight each
-    #                   sample in the batch separately, +sample_weight+
-    #                   should have shape (64, 1).
-    #
-    # ====Returns
-    #
-    # Weighted loss
-    #
-    def apply_weighting(clazz, loss, weight = nil, sample_weight = nil)
-      unless sample_weight.nil?
-        loss = clazz.broadcast_mul(loss, sample_weight)
-      end
-      unless weight.nil?
-        raise ArgumentError, 'weight must be numeric' unless weight.is_a?(Numeric)
-        loss = loss * weight
-      end
-      loss
-    end
+
     ##
     # Calculates the mean absolute error between prediction and label.
     #
@@ -83,6 +54,7 @@ module MXNet::Gluon
       def initialize(weight: nil, batch_axis: 0, **kwargs)
         super(weight: weight, batch_axis: batch_axis, **kwargs)
       end
+
       def hybrid_forward(clazz, prediction, label, sample_weight: nil)
         label = clazz.reshape_like(label, prediction)
         loss = clazz.abs(prediction - label)
@@ -90,9 +62,11 @@ module MXNet::Gluon
         clazz.mean(loss, axis: @batch_axis, exclude: true)
       end
     end
+
     def self.L1Loss(*args)
       L1Loss.new(*args)
     end
+
     ##
     # Calculates the mean squared error between prediction and label.
     #
@@ -113,6 +87,7 @@ module MXNet::Gluon
       def initialize(weight: 1.0, batch_axis: 0, **kwargs)
         super(weight: weight, batch_axis: batch_axis, **kwargs)
       end
+
       def hybrid_forward(clazz, prediction, label, sample_weight: nil)
         label = clazz.reshape_like(label, prediction)
         loss = clazz.square(prediction - label)
@@ -120,9 +95,11 @@ module MXNet::Gluon
         clazz.mean(loss, axis: @batch_axis, exclude: true)
       end
     end
+
     def self.L2Loss(*args)
       L2Loss.new(*args)
     end
+
     ##
     # Computes the softmax cross-entropy loss.
     #
@@ -164,6 +141,7 @@ module MXNet::Gluon
         @from_logits = from_logits
         super(weight: weight, batch_axis: batch_axis, **kwargs)
       end
+
       def hybrid_forward(clazz, prediction, label, sample_weight: nil)
         unless @from_logits
           prediction = clazz.log_softmax(prediction, axis: @axis)
@@ -178,8 +156,42 @@ module MXNet::Gluon
         clazz.mean(loss, axis: @batch_axis, exclude: true)
       end
     end
+
     def self.SoftmaxCrossEntropyLoss(*args)
       SoftmaxCrossEntropyLoss.new(*args)
+    end
+
+    protected
+
+    ##
+    # Apply weighting to loss.
+    #
+    # ====Parameters
+    #
+    # +loss+::          (Symbol or NDArray)
+    #                   The loss to be weighted.
+    # +weight+::        (float or +nil+)
+    #                   Global scalar weight for loss.
+    # +sample_weight+:: (Symbol, NDArray or +nil+)
+    #                   Per sample weighting. Must be broadcastable to
+    #                   the same shape as loss. For example, if loss
+    #                   has shape (64, 10) and you want to weight each
+    #                   sample in the batch separately, +sample_weight+
+    #                   should have shape (64, 1).
+    #
+    # ====Returns
+    #
+    # Weighted loss
+    #
+    def apply_weighting(clazz, loss, weight = nil, sample_weight = nil)
+      unless sample_weight.nil?
+        loss = clazz.broadcast_mul(loss, sample_weight)
+      end
+      unless weight.nil?
+        raise ArgumentError, 'weight must be numeric' unless weight.is_a?(Numeric)
+        loss = loss * weight
+      end
+      loss
     end
   end
 end

--- a/lib/mxnet/gluon/loss.rb
+++ b/lib/mxnet/gluon/loss.rb
@@ -5,7 +5,19 @@ module MXNet::Gluon
   # Base class for loss.
   #
   class Loss < MXNet::Gluon::HybridBlock
-    def initialize(**kwargs)
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +weight+::     (float or +nil+)
+    #                Global scalar weight for loss.
+    # +batch_axis+:: (integer, default 0)
+    #                The axis that represents mini-batch.
+    #
+    def initialize(weight: 1.0, batch_axis: 0, **kwargs)
+      @weight = weight
+      @batch_axis = batch_axis
       super(**kwargs)
     end
     ##
@@ -63,6 +75,36 @@ module MXNet::Gluon
       loss
     end
     ##
+    # Calculates the mean absolute error between prediction and label.
+    #
+    # Inputs "prediction" and "label" can have arbitrary shape as long
+    # as they have the same number of elements.
+    #
+    class L1Loss < Loss
+      ##
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +weight+::     (float or +nil+)
+      #                Global scalar weight for loss.
+      # +batch_axis+:: (integer, default 0)
+      #                The axis that represents mini-batch.
+      #
+      def initialize(**kwargs)
+        super(**kwargs)
+      end
+      def hybrid_forward(clazz, prediction, label, sample_weight: nil)
+        label = reshape_like(clazz, label, prediction)
+        loss = clazz.abs(prediction - label)
+        loss = apply_weighting(clazz, loss, @weight, sample_weight)
+        clazz.mean(loss, axis: @batch_axis, exclude: true)
+      end
+    end
+    def self.L1Loss(*args)
+      L1Loss.new(*args)
+    end
+    ##
     # Calculates the mean squared error between prediction and label.
     #
     # Inputs "prediction" and "label" can have arbitrary shape as long
@@ -79,14 +121,10 @@ module MXNet::Gluon
       # +batch_axis+:: (integer, default 0)
       #                The axis that represents mini-batch.
       #
-      def initialize(weight: 1.0, batch_axis: 0, **kwargs)
+      def initialize(**kwargs)
         super(**kwargs)
-        @weight = weight
-        @batch_axis = batch_axis
       end
-      def hybrid_forward(clazz, prediction = nil, label = nil, sample_weight: nil, **kwargs)
-        prediction ||= kwargs[:prediction]
-        label ||= kwargs[:label]
+      def hybrid_forward(clazz, prediction, label, sample_weight: nil)
         label = reshape_like(clazz, label, prediction)
         loss = clazz.square(prediction - label)
         loss = apply_weighting(clazz, loss, @weight/2, sample_weight)
@@ -95,6 +133,53 @@ module MXNet::Gluon
     end
     def self.L2Loss(*args)
       L2Loss.new(*args)
+    end
+    ##
+    # Computes the softmax cross-entropy loss.
+    #
+    class SoftmaxCrossEntropyLoss < Loss
+      ##
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +axis+::         (integer, default -1)
+      #                  The axis to sum over when computing softmax
+      #                  and entropy.
+      # +sparse_label+:: (boolean, default +true+)
+      #                  Whether label is an integer array instead of
+      #                  probability distribution.
+      # +from_logits+::  (boolean, default +false+)
+      #                  Whether input is a log probability (usually
+      #                  from #log_softmax) instead of unnormalized
+      #                  numbers.
+      # +weight+::       (float or +nil+)
+      #                  Global scalar weight for loss.
+      # +batch_axis+::   (integer, default 0)
+      #                  The axis that represents mini-batch.
+      #
+      def initialize(axis: -1, sparse_label: true, from_logits: false, **kwargs)
+        @axis = axis
+        @sparse_label = sparse_label
+        @from_logits = from_logits
+        super(**kwargs)
+      end
+      def hybrid_forward(clazz, prediction, label, sample_weight: nil)
+        unless @from_logits
+          prediction = clazz.log_softmax(prediction, axis: @axis)
+        end
+        if @sparse_label
+          loss = -clazz.pick(prediction, label, axis: @axis, keepdims: true)
+        else
+          label = reshape_like(clazz, label, prediction)
+          loss = -clazz.sum(prediction * label, axis: @axis, keepdims: true)
+        end
+        loss = apply_weighting(clazz, loss, @weight, sample_weight)
+        clazz.mean(loss, axis: @batch_axis, exclude: true)
+      end
+    end
+    def self.SoftmaxCrossEntropyLoss(*args)
+      SoftmaxCrossEntropyLoss.new(*args)
     end
   end
 end

--- a/lib/mxnet/gluon/loss.rb
+++ b/lib/mxnet/gluon/loss.rb
@@ -1,197 +1,199 @@
 require 'mxnet/gluon/block'
 
-module MXNet::Gluon
-  ##
-  # Base class for loss.
-  #
-  class Loss < MXNet::Gluon::HybridBlock
+module MXNet
+  module Gluon
     ##
-    # Creates a new instance.
+    # Base class for loss.
     #
-    # ====Parameters
-    #
-    # +weight+::     (float or +nil+)
-    #                Global scalar weight for loss.
-    # +batch_axis+:: (integer)
-    #                The axis that represents the
-    #                mini-batch.
-    #
-    def initialize(weight:, batch_axis:, **kwargs)
-      @weight = weight
-      @batch_axis = batch_axis
-      super(**kwargs)
-    end
-
-    ##
-    # Override to construct symbolic graph for this Block.
-    #
-    # ====Parameters
-    #
-    # +args+:: (array of NDArray or Symbol) Input tensors.
-    #
-    #
-    def hybrid_forward(clazz, *args)
-      raise NotImplementedError
-    end
-
-    ##
-    # Calculates the mean absolute error between prediction and label.
-    #
-    # Inputs "prediction" and "label" can have arbitrary shape as long
-    # as they have the same number of elements.
-    #
-    class L1Loss < Loss
+    class Loss < MXNet::Gluon::HybridBlock
       ##
       # Creates a new instance.
       #
       # ====Parameters
       #
-      # +weight+::     (float or +nil+, default +nil+)
+      # +weight+::     (float or +nil+)
       #                Global scalar weight for loss.
-      # +batch_axis+:: (integer, default 0)
-      #                The axis that represents mini-batch.
+      # +batch_axis+:: (integer)
+      #                The axis that represents the
+      #                mini-batch.
       #
-      def initialize(weight: nil, batch_axis: 0, **kwargs)
-        super(weight: weight, batch_axis: batch_axis, **kwargs)
+      def initialize(weight:, batch_axis:, **kwargs)
+        @weight = weight
+        @batch_axis = batch_axis
+        super(**kwargs)
       end
 
-      def hybrid_forward(clazz, prediction, label, sample_weight: nil)
-        label = clazz.reshape_like(label, prediction)
-        loss = clazz.abs(prediction - label)
-        loss = apply_weighting(clazz, loss, @weight, sample_weight)
-        clazz.mean(loss, axis: @batch_axis, exclude: true)
-      end
-    end
-
-    def self.L1Loss(*args)
-      L1Loss.new(*args)
-    end
-
-    ##
-    # Calculates the mean squared error between prediction and label.
-    #
-    # Inputs "prediction" and "label" can have arbitrary shape as long
-    # as they have the same number of elements.
-    #
-    class L2Loss < Loss
       ##
-      # Creates a new instance.
+      # Override to construct symbolic graph for this Block.
       #
       # ====Parameters
       #
-      # +weight+::     (float or +nil+, default 1.0)
-      #                Global scalar weight for loss.
-      # +batch_axis+:: (integer, default 0)
-      #                The axis that represents mini-batch.
+      # +args+:: (array of NDArray or Symbol) Input tensors.
       #
-      def initialize(weight: 1.0, batch_axis: 0, **kwargs)
-        super(weight: weight, batch_axis: batch_axis, **kwargs)
+      #
+      def hybrid_forward(clazz, *args)
+        raise NotImplementedError
       end
 
-      def hybrid_forward(clazz, prediction, label, sample_weight: nil)
-        label = clazz.reshape_like(label, prediction)
-        loss = clazz.square(prediction - label)
-        loss = apply_weighting(clazz, loss, @weight/2, sample_weight)
-        clazz.mean(loss, axis: @batch_axis, exclude: true)
-      end
-    end
-
-    def self.L2Loss(*args)
-      L2Loss.new(*args)
-    end
-
-    ##
-    # Computes the softmax cross-entropy loss.
-    #
-    # If +sparse_label+ is +true+ (default), labels should contain
-    # integer category indicators. The labels' shape should be the
-    # predictions' shape with the +axis+ dimension removed -- i.e. for
-    # predictions with shape <tt>[1, 2, 3, 4]</tt> and <tt>axis: 2</tt>,
-    # labels' shape should be <tt>[1, 2, 4]</tt>.
-    #
-    # If +sparse_label+ is +false+, labels should contain probability
-    # distributions and labels' shape should be the same as
-    # predictions' shape.
-    #
-    class SoftmaxCrossEntropyLoss < Loss
       ##
-      # Creates a new instance.
+      # Calculates the mean absolute error between prediction and label.
       #
-      # ====Parameters
+      # Inputs "prediction" and "label" can have arbitrary shape as long
+      # as they have the same number of elements.
       #
-      # +axis+::         (integer, default -1)
-      #                  The axis to sum over when computing softmax
-      #                  and entropy.
-      # +sparse_label+:: (boolean, default +true+)
-      #                  Whether label is an integer array instead of
-      #                  probability distribution.
-      # +from_logits+::  (boolean, default +false+)
-      #                  Whether prediction is a log probability
-      #                  (usually from #log_softmax) instead of
-      #                  unnormalized numbers.
-      # +weight+::       (float or +nil+, default +nil+)
-      #                  Global scalar weight for loss.
-      # +batch_axis+::   (integer, default 0)
-      #                  The axis that represents mini-batch.
-      #
-      def initialize(axis: -1, sparse_label: true, from_logits: false,
-                     weight: nil, batch_axis: 0, **kwargs)
-        @axis = axis
-        @sparse_label = sparse_label
-        @from_logits = from_logits
-        super(weight: weight, batch_axis: batch_axis, **kwargs)
-      end
-
-      def hybrid_forward(clazz, prediction, label, sample_weight: nil)
-        unless @from_logits
-          prediction = clazz.log_softmax(prediction, axis: @axis)
+      class L1Loss < Loss
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +weight+::     (float or +nil+, default +nil+)
+        #                Global scalar weight for loss.
+        # +batch_axis+:: (integer, default 0)
+        #                The axis that represents mini-batch.
+        #
+        def initialize(weight: nil, batch_axis: 0, **kwargs)
+          super(weight: weight, batch_axis: batch_axis, **kwargs)
         end
-        if @sparse_label
-          loss = -clazz.pick(prediction, label, axis: @axis, keepdims: true)
-        else
+
+        def hybrid_forward(clazz, prediction, label, sample_weight: nil)
           label = clazz.reshape_like(label, prediction)
-          loss = -clazz.sum(prediction * label, axis: @axis, keepdims: true)
+          loss = clazz.abs(prediction - label)
+          loss = apply_weighting(clazz, loss, @weight, sample_weight)
+          clazz.mean(loss, axis: @batch_axis, exclude: true)
         end
-        loss = apply_weighting(clazz, loss, @weight, sample_weight)
-        clazz.mean(loss, axis: @batch_axis, exclude: true)
       end
-    end
 
-    def self.SoftmaxCrossEntropyLoss(*args)
-      SoftmaxCrossEntropyLoss.new(*args)
-    end
-
-    protected
-
-    ##
-    # Apply weighting to loss.
-    #
-    # ====Parameters
-    #
-    # +loss+::          (Symbol or NDArray)
-    #                   The loss to be weighted.
-    # +weight+::        (float or +nil+)
-    #                   Global scalar weight for loss.
-    # +sample_weight+:: (Symbol, NDArray or +nil+)
-    #                   Per sample weighting. Must be broadcastable to
-    #                   the same shape as loss. For example, if loss
-    #                   has shape (64, 10) and you want to weight each
-    #                   sample in the batch separately, +sample_weight+
-    #                   should have shape (64, 1).
-    #
-    # ====Returns
-    #
-    # Weighted loss
-    #
-    def apply_weighting(clazz, loss, weight = nil, sample_weight = nil)
-      unless sample_weight.nil?
-        loss = clazz.broadcast_mul(loss, sample_weight)
+      def self.L1Loss(*args)
+        L1Loss.new(*args)
       end
-      unless weight.nil?
-        raise ArgumentError, 'weight must be numeric' unless weight.is_a?(Numeric)
-        loss = loss * weight
+
+      ##
+      # Calculates the mean squared error between prediction and label.
+      #
+      # Inputs "prediction" and "label" can have arbitrary shape as long
+      # as they have the same number of elements.
+      #
+      class L2Loss < Loss
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +weight+::     (float or +nil+, default 1.0)
+        #                Global scalar weight for loss.
+        # +batch_axis+:: (integer, default 0)
+        #                The axis that represents mini-batch.
+        #
+        def initialize(weight: 1.0, batch_axis: 0, **kwargs)
+          super(weight: weight, batch_axis: batch_axis, **kwargs)
+        end
+
+        def hybrid_forward(clazz, prediction, label, sample_weight: nil)
+          label = clazz.reshape_like(label, prediction)
+          loss = clazz.square(prediction - label)
+          loss = apply_weighting(clazz, loss, @weight/2, sample_weight)
+          clazz.mean(loss, axis: @batch_axis, exclude: true)
+        end
       end
-      loss
+
+      def self.L2Loss(*args)
+        L2Loss.new(*args)
+      end
+
+      ##
+      # Computes the softmax cross-entropy loss.
+      #
+      # If +sparse_label+ is +true+ (default), labels should contain
+      # integer category indicators. The labels' shape should be the
+      # predictions' shape with the +axis+ dimension removed -- i.e. for
+      # predictions with shape <tt>[1, 2, 3, 4]</tt> and <tt>axis: 2</tt>,
+      # labels' shape should be <tt>[1, 2, 4]</tt>.
+      #
+      # If +sparse_label+ is +false+, labels should contain probability
+      # distributions and labels' shape should be the same as
+      # predictions' shape.
+      #
+      class SoftmaxCrossEntropyLoss < Loss
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +axis+::         (integer, default -1)
+        #                  The axis to sum over when computing softmax
+        #                  and entropy.
+        # +sparse_label+:: (boolean, default +true+)
+        #                  Whether label is an integer array instead of
+        #                  probability distribution.
+        # +from_logits+::  (boolean, default +false+)
+        #                  Whether prediction is a log probability
+        #                  (usually from #log_softmax) instead of
+        #                  unnormalized numbers.
+        # +weight+::       (float or +nil+, default +nil+)
+        #                  Global scalar weight for loss.
+        # +batch_axis+::   (integer, default 0)
+        #                  The axis that represents mini-batch.
+        #
+        def initialize(axis: -1, sparse_label: true, from_logits: false,
+                       weight: nil, batch_axis: 0, **kwargs)
+          @axis = axis
+          @sparse_label = sparse_label
+          @from_logits = from_logits
+          super(weight: weight, batch_axis: batch_axis, **kwargs)
+        end
+
+        def hybrid_forward(clazz, prediction, label, sample_weight: nil)
+          unless @from_logits
+            prediction = clazz.log_softmax(prediction, axis: @axis)
+          end
+          if @sparse_label
+            loss = -clazz.pick(prediction, label, axis: @axis, keepdims: true)
+          else
+            label = clazz.reshape_like(label, prediction)
+            loss = -clazz.sum(prediction * label, axis: @axis, keepdims: true)
+          end
+          loss = apply_weighting(clazz, loss, @weight, sample_weight)
+          clazz.mean(loss, axis: @batch_axis, exclude: true)
+        end
+      end
+
+      def self.SoftmaxCrossEntropyLoss(*args)
+        SoftmaxCrossEntropyLoss.new(*args)
+      end
+
+      protected
+
+      ##
+      # Apply weighting to loss.
+      #
+      # ====Parameters
+      #
+      # +loss+::          (Symbol or NDArray)
+      #                   The loss to be weighted.
+      # +weight+::        (float or +nil+)
+      #                   Global scalar weight for loss.
+      # +sample_weight+:: (Symbol, NDArray or +nil+)
+      #                   Per sample weighting. Must be broadcastable to
+      #                   the same shape as loss. For example, if loss
+      #                   has shape (64, 10) and you want to weight each
+      #                   sample in the batch separately, +sample_weight+
+      #                   should have shape (64, 1).
+      #
+      # ====Returns
+      #
+      # Weighted loss
+      #
+      def apply_weighting(clazz, loss, weight = nil, sample_weight = nil)
+        unless sample_weight.nil?
+          loss = clazz.broadcast_mul(loss, sample_weight)
+        end
+        unless weight.nil?
+          raise ArgumentError, 'weight must be numeric' unless weight.is_a?(Numeric)
+          loss = loss * weight
+        end
+        loss
+      end
     end
   end
 end

--- a/lib/mxnet/gluon/loss.rb
+++ b/lib/mxnet/gluon/loss.rb
@@ -190,7 +190,7 @@ module MXNet
         end
         unless weight.nil?
           raise ArgumentError, 'weight must be numeric' unless weight.is_a?(Numeric)
-          loss = loss * weight
+          loss *= weight
         end
         loss
       end

--- a/lib/mxnet/gluon/nn.rb
+++ b/lib/mxnet/gluon/nn.rb
@@ -5,4 +5,5 @@ module MXNet::Gluon
   end
 end
 
+require_relative 'nn/activations'
 require_relative 'nn/layers'

--- a/lib/mxnet/gluon/nn.rb
+++ b/lib/mxnet/gluon/nn.rb
@@ -1,0 +1,8 @@
+require 'mxnet/gluon'
+
+module MXNet::Gluon
+  module NN
+  end
+end
+
+require_relative 'nn/layers'

--- a/lib/mxnet/gluon/nn/activations.rb
+++ b/lib/mxnet/gluon/nn/activations.rb
@@ -21,6 +21,10 @@ module MXNet::Gluon::NN
     def hybrid_forward(clazz, data)
       clazz.Activation(data, act_type: @activation)
     end
+    private
+    def hint
+      @activation
+    end
   end
   def self.Activation(*args)
     Activation.new(*args)

--- a/lib/mxnet/gluon/nn/activations.rb
+++ b/lib/mxnet/gluon/nn/activations.rb
@@ -1,36 +1,40 @@
 require 'mxnet/gluon/block'
 require 'mxnet/gluon/nn'
 
-module MXNet::Gluon::NN
-  ##
-  # Applies an activation function.
-  #
-  class Activation < MXNet::Gluon::HybridBlock
-    ##
-    # Creates a new instance.
-    #
-    # ====Parameters
-    #
-    # +activation+:: (string)
-    #                Name of activation function to use.
-    #
-    def initialize(activation, **kwargs)
-      super(**kwargs)
-      @activation = activation
+module MXNet
+  module Gluon
+    module NN
+      ##
+      # Applies an activation function.
+      #
+      class Activation < MXNet::Gluon::HybridBlock
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +activation+:: (string)
+        #                Name of activation function to use.
+        #
+        def initialize(activation, **kwargs)
+          super(**kwargs)
+          @activation = activation
+        end
+
+        def hybrid_forward(clazz, data)
+          clazz.Activation(data, act_type: @activation)
+        end
+
+        private
+
+        def hint
+          @activation
+        end
+      end
+
+      def self.Activation(*args)
+        Activation.new(*args)
+      end
     end
-
-    def hybrid_forward(clazz, data)
-      clazz.Activation(data, act_type: @activation)
-    end
-
-    private
-
-    def hint
-      @activation
-    end
-  end
-
-  def self.Activation(*args)
-    Activation.new(*args)
   end
 end

--- a/lib/mxnet/gluon/nn/activations.rb
+++ b/lib/mxnet/gluon/nn/activations.rb
@@ -18,14 +18,18 @@ module MXNet::Gluon::NN
       super(**kwargs)
       @activation = activation
     end
+
     def hybrid_forward(clazz, data)
       clazz.Activation(data, act_type: @activation)
     end
+
     private
+
     def hint
       @activation
     end
   end
+
   def self.Activation(*args)
     Activation.new(*args)
   end

--- a/lib/mxnet/gluon/nn/activations.rb
+++ b/lib/mxnet/gluon/nn/activations.rb
@@ -1,0 +1,28 @@
+require 'mxnet/gluon/block'
+require 'mxnet/gluon/nn'
+
+module MXNet::Gluon::NN
+  ##
+  # Applies an activation function.
+  #
+  class Activation < MXNet::Gluon::HybridBlock
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +activation+:: (string)
+    #                Name of activation function to use.
+    #
+    def initialize(activation, **kwargs)
+      super(**kwargs)
+      @activation = activation
+    end
+    def hybrid_forward(clazz, data)
+      clazz.Activation(data, act_type: @activation)
+    end
+  end
+  def self.Activation(*args)
+    Activation.new(*args)
+  end
+end

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -1,0 +1,22 @@
+require 'mxnet/gluon/block'
+require 'mxnet/gluon/nn'
+
+module MXNet::Gluon::NN
+  def self.Dense(*args)
+    Dense.new(*args)
+  end
+  class Dense < MXNet::Gluon::HybridBlock
+    def initialize(units, use_bias: true, in_units: 0, **kwargs)
+      super(**kwargs)
+      @units = units
+      @in_units = in_units
+      self.weight = params.get('weight', shape: [units, in_units])
+      self.bias = use_bias ? params.get('bias', shape: [units]) : nil
+    end
+    def hybrid_forward(clazz, data, weight = nil, bias = nil, **kwargs)
+      weight ||= kwargs[:weight]
+      bias ||= kwargs[:bias]
+      clazz.FullyConnected(data, weight, bias, no_bias: bias.nil?, num_hidden: @units)
+    end
+  end
+end

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -71,29 +71,31 @@ module MXNet::Gluon::NN
     #
     def initialize(units, use_bias: true, activation: nil, in_units: 0, **kwargs)
       super(**kwargs)
-      @units = units
-      @in_units = in_units
-      self.weight = params.get(
-        'weight',
-        shape: [units, in_units],
-        allow_deferred_init: true
-      )
-      if use_bias
-        self.bias = params.get(
-          'bias',
-          shape: [units],
+      self.with_name_scope do
+        @units = units
+        @in_units = in_units
+        self.weight = params.get(
+          'weight',
+          shape: [units, in_units],
           allow_deferred_init: true
         )
-      else
-        self.bias = nil
-      end
-      if activation
-        self.act = MXNet::Gluon::NN.Activation(
-          activation,
-          prefix: "#{activation}_"
-        )
-      else
-        self.act = nil
+        if use_bias
+          self.bias = params.get(
+            'bias',
+            shape: [units],
+            allow_deferred_init: true
+          )
+        else
+          self.bias = nil
+        end
+        if activation
+          self.act = MXNet::Gluon::NN.Activation(
+            activation,
+            prefix: "#{activation}_"
+          )
+        else
+          self.act = nil
+        end
       end
     end
     def hybrid_forward(clazz, data, weight = nil, bias = nil, **kwargs)

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -18,24 +18,28 @@ module MXNet::Gluon::NN
     def initialize(**kwargs)
       super(**kwargs)
     end
+
     ##
     # Adds blocks on top of the stack.
     #
     def add(*blocks)
       blocks.each { |block| register_child(block) }
     end
+
     ##
     # Returns the number of blocks in the sequential stack.
     #
     def length
       children.length
     end
+
     ##
     # Returns the block at the specified index.
     #
     def at(index)
       children[index]
     end
+
     ##
     # Runs a forward pass on all child blocks.
     #
@@ -43,9 +47,11 @@ module MXNet::Gluon::NN
       children.inject(data) { |data, child| child.forward(data) }
     end
   end
+
   def self.Sequential(*args)
     Sequential.new(*args)
   end
+
   ##
   # Stacks HybridBlocks sequentially.
   #
@@ -63,24 +69,28 @@ module MXNet::Gluon::NN
     def initialize(**kwargs)
       super(**kwargs)
     end
+
     ##
     # Adds blocks on top of the stack.
     #
     def add(*blocks)
       blocks.each { |block| register_child(block) }
     end
+
     ##
     # Returns the number of blocks in the sequential stack.
     #
     def length
       children.length
     end
+
     ##
     # Returns the block at the specified index.
     #
     def at(index)
       children[index]
     end
+
     ##
     # Runs a forward pass on all child blocks.
     #
@@ -88,9 +98,11 @@ module MXNet::Gluon::NN
       children.inject(data) { |data, child| child.forward(data) }
     end
   end
+
   def self.HybridSequential(*args)
     HybridSequential.new(*args)
   end
+
   ##
   # Just your regular densely-connected neural network layer.
   #
@@ -157,6 +169,7 @@ module MXNet::Gluon::NN
         end
       end
     end
+
     def hybrid_forward(clazz, data, weight:, bias: nil)
       out = clazz.FullyConnected(
         data,
@@ -171,9 +184,11 @@ module MXNet::Gluon::NN
       out
     end
   end
+
   def self.Dense(*args)
     Dense.new(*args)
   end
+
   module Internal
     ##
     # Base class for convolution layers.
@@ -282,6 +297,7 @@ module MXNet::Gluon::NN
           end
         end
       end
+
       def hybrid_forward(clazz, data, weight:, bias: nil)
         kwargs = @kwargs.merge(no_bias: bias.nil?)
         out = clazz.send(@op_name, data, weight, bias, **kwargs)
@@ -290,16 +306,20 @@ module MXNet::Gluon::NN
         end
         out
       end
+
       private
+
       def infer_weight_shape(op_name, shape, **kwargs)
         sym = MXNet::Symbol.var('data', shape: shape)
         sym = MXNet::Symbol.send(op_name, sym, **kwargs)
         sym.infer_shape_partial[0]
       end
+
       def hint
         'conv'
       end
     end
+
     ##
     # Base class for pooling layers.
     #
@@ -342,15 +362,19 @@ module MXNet::Gluon::NN
           pad: padding
         }
       end
+
       def hybrid_forward(clazz, data)
         clazz.Pooling(data, **@kwargs)
       end
+
       private
+
       def hint
         'pool'
       end
     end
   end
+
   ##
   # 2D convolution layer (e.g. spatial convolution over images).
   #
@@ -430,9 +454,11 @@ module MXNet::Gluon::NN
       )
     end
   end
+
   def self.Conv2D(*args)
     Conv2D.new(*args)
   end
+
   ##
   # Max pooling operation for 2D data (e.g. images).
   #
@@ -472,9 +498,11 @@ module MXNet::Gluon::NN
       )
     end
   end
+
   def self.MaxPool2D(*args)
     MaxPool2D.new(*args)
   end
+
   ##
   # Flattens the input to two dimensions.
   #
@@ -493,10 +521,12 @@ module MXNet::Gluon::NN
     def initialize(**kwargs)
       super(**kwargs)
     end
+
     def hybrid_forward(clazz, data)
       clazz.flatten(data)
     end
   end
+
   def self.Flatten(*args)
     Flatten.new(*args)
   end

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -77,12 +77,14 @@ module MXNet::Gluon::NN
         self.weight = params.get(
           'weight',
           shape: [units, in_units],
+          init: nil,
           allow_deferred_init: true
         )
         if use_bias
           self.bias = params.get(
             'bias',
             shape: [units],
+            init: :zeros,
             allow_deferred_init: true
           )
         else
@@ -202,12 +204,14 @@ module MXNet::Gluon::NN
           self.weight = self.params.get(
             'weight',
             shape: wshape,
+            init: nil,
             allow_deferred_init: true
           )
           if use_bias
             self.bias = self.params.get(
               'bias',
               shape: bshape,
+              init: :zeros,
               allow_deferred_init: true
             )
           else

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -38,7 +38,7 @@ module MXNet
         ##
         # Returns the block at the specified index.
         #
-        def at(index)
+        def [](index)
           children[index]
         end
 
@@ -89,7 +89,7 @@ module MXNet
         ##
         # Returns the block at the specified index.
         #
-        def at(index)
+        def [](index)
           children[index]
         end
 
@@ -181,7 +181,7 @@ module MXNet
             num_hidden: @units
           )
           if self.act
-            out = self.act[out]
+            out = self.act.forward(out)
           end
           out
         end
@@ -304,7 +304,7 @@ module MXNet
             kwargs = @kwargs.merge(no_bias: bias.nil?)
             out = clazz.send(@op_name, data, weight, bias, **kwargs)
             if self.act
-              out = self.act[out]
+              out = self.act.forward(out)
             end
             out
           end

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -112,9 +112,7 @@ module MXNet::Gluon::NN
         end
       end
     end
-    def hybrid_forward(clazz, data, weight = nil, bias = nil, **kwargs)
-      weight ||= kwargs[:weight]
-      bias ||= kwargs[:bias]
+    def hybrid_forward(clazz, data, weight:, bias: nil)
       out = clazz.FullyConnected(
         data,
         weight,
@@ -239,14 +237,9 @@ module MXNet::Gluon::NN
           end
         end
       end
-      def hybrid_forward(clazz, data, weight = nil, bias = nil, **kwargs)
-        weight ||= kwargs[:weight]
-        bias ||= kwargs[:bias]
-        if bias.nil?
-          out = clazz.send(@op_name, data, weight, **@kwargs)
-        else
-          out = clazz.send(@op_name, data, weight, bias, **@kwargs)
-        end
+      def hybrid_forward(clazz, data, weight:, bias: nil)
+        kwargs = @kwargs.merge(no_bias: bias.nil?)
+        out = clazz.send(@op_name, data, weight, bias, **kwargs)
         if self.act
           out = self.act[out]
         end

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -40,11 +40,56 @@ module MXNet::Gluon::NN
     # Runs a forward pass on all child blocks.
     #
     def forward(data)
-      children.inject(data) { |data, child| child[data] }
+      children.inject(data) { |data, child| child.forward(data) }
     end
   end
   def self.Sequential(*args)
     Sequential.new(*args)
+  end
+  ##
+  # Stacks HybridBlocks sequentially.
+  #
+  #     net = MXNet::Gluon::NN.HybridSequential
+  #     net.with_name_scope do
+  #       net.add(MXNet::Gluon::NN.Dense(10, activation: :relu))
+  #       net.add(MXNet::Gluon::NN.Dense(20))
+  #     end
+  #     net.hybridize
+  #
+  class HybridSequential < MXNet::Gluon::HybridBlock
+    ##
+    # Creates a new instance.
+    #
+    def initialize(**kwargs)
+      super(**kwargs)
+    end
+    ##
+    # Adds blocks on top of the stack.
+    #
+    def add(*blocks)
+      blocks.each { |block| register_child(block) }
+    end
+    ##
+    # Returns the number of blocks in the sequential stack.
+    #
+    def length
+      children.length
+    end
+    ##
+    # Returns the block at the specified index.
+    #
+    def at(index)
+      children[index]
+    end
+    ##
+    # Runs a forward pass on all child blocks.
+    #
+    def hybrid_forward(clazz, data)
+      children.inject(data) { |data, child| child.forward(data) }
+    end
+  end
+  def self.HybridSequential(*args)
+    HybridSequential.new(*args)
   end
   ##
   # Just your regular densely-connected neural network layer.

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -3,6 +3,38 @@ require 'mxnet/gluon/nn'
 
 module MXNet::Gluon::NN
   ##
+  # Stacks blocks sequentially.
+  #
+  #     net = MXNet::Gluon::NN.Sequential
+  #     net.with_name_scope do
+  #       net.add(MXNet::Gluon::NN.Dense(10, activation: :relu))
+  #       net.add(MXNet::Gluon::NN.Dense(20))
+  #     end
+  #
+  class Sequential < MXNet::Gluon::Block
+    ##
+    # Creates a new instance.
+    #
+    def initialize(**kwargs)
+      super(**kwargs)
+    end
+    ##
+    # Adds blocks on top of the stack.
+    #
+    def add(*blocks)
+      blocks.each { |block| register_child(block) }
+    end
+    ##
+    # Runs a forward pass on all child blocks.
+    #
+    def forward(data)
+      children.inject(data) { |data, child| child[data] }
+    end
+  end
+  def self.Sequential(*args)
+    Sequential.new(*args)
+  end
+  ##
   # Just your regular densely-connected neural network layer.
   #
   # Implements the operation:

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -25,6 +25,18 @@ module MXNet::Gluon::NN
       blocks.each { |block| register_child(block) }
     end
     ##
+    # Returns the number of blocks in the sequential stack.
+    #
+    def length
+      children.length
+    end
+    ##
+    # Returns the block at the specified index.
+    #
+    def at(index)
+      children[index]
+    end
+    ##
     # Runs a forward pass on all child blocks.
     #
     def forward(data)

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -5,18 +5,62 @@ module MXNet::Gluon::NN
   def self.Dense(*args)
     Dense.new(*args)
   end
+  ##
+  # Just your regular densely-connected neural network layer.
+  #
+  # Implements the operation:
+  #
+  #     output = activation(dot(input, weight) + bias)
+  #
+  # where `activation` is the element-wise activation function passed
+  # as the "activation" argument, `weight` is a weights matrix created
+  # by the layer, and `bias` is a bias vector created by the layer
+  # (if "use_bias" is +true+).
+  #
+  # Note: "input" must be a tensor with rank two. Use "flatten" to
+  # convert it to rank two if necessary.
+  #
   class Dense < MXNet::Gluon::HybridBlock
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +use_bias+:: (boolean)
+    #              Whether the layer uses a bias vector.
+    # +in_units+:: (integer, optional)
+    #              Size of the input data. If not specified,
+    #              initialization will be deferred to the first time
+    #              #forward is called and `in_units` will be inferred
+    #              from the shape of input data.
+    #
     def initialize(units, use_bias: true, in_units: 0, **kwargs)
       super(**kwargs)
       @units = units
       @in_units = in_units
-      self.weight = params.get('weight', shape: [units, in_units])
-      self.bias = use_bias ? params.get('bias', shape: [units]) : nil
+      self.weight = params.get(
+        'weight',
+        shape: [units, in_units],
+        allow_deferred_init: true
+      )
+      if use_bias
+        self.bias = params.get(
+          'bias',
+          shape: [units],
+          allow_deferred_init: true
+        )
+      else
+        self.bias = nil
+      end
     end
     def hybrid_forward(clazz, data, weight = nil, bias = nil, **kwargs)
       weight ||= kwargs[:weight]
       bias ||= kwargs[:bias]
       clazz.FullyConnected(data, weight, bias, no_bias: bias.nil?, num_hidden: @units)
+    end
+    private
+    def deferred_infer_shape(*args)
+      # FIXME: for now, punted to the subclass
+      self.weight.shape = [@units, args.first.shape[1]]
     end
   end
 end

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -41,13 +41,13 @@ module MXNet::Gluon::NN
   #
   #     output = activation(dot(input, weight) + bias)
   #
-  # where `activation` is the element-wise activation function passed
-  # as the "activation" argument, `weight` is a weights matrix created
-  # by the layer, and `bias` is a bias vector created by the layer
-  # (if "use_bias" is +true+).
+  # where +activation+ is the element-wise activation function passed
+  # as the +activation+ argument, +weight+ is a weights matrix created
+  # by the layer, and +bias+ is a bias vector created by the layer
+  # (if argument +use_bias+ is +true+).
   #
-  # Note: "input" must be a tensor with rank two. Use "flatten" to
-  # convert it to rank two if necessary.
+  # Note: +input+ must be a tensor with rank two. Use
+  # MXNet::NDArray#flatten to convert it to rank two if necessary.
   #
   class Dense < MXNet::Gluon::HybridBlock
     ##
@@ -62,11 +62,11 @@ module MXNet::Gluon::NN
     # +activation+:: (string, optional)
     #                Activation function to use. If nothing is
     #                specified, no activation is applied (it acts like
-    #                "linear" activation: `a(x) = x`).
+    #                "linear" activation: <tt>a(x) = x</tt>).
     # +in_units+::   (integer, optional)
     #                Size of the input data. If not specified,
     #                initialization will be deferred to the first time
-    #                #forward is called and `in_units` will be
+    #                #forward is called and +in_units+ will be
     #                inferred from the shape of input data.
     #
     def initialize(units, use_bias: true, activation: nil, in_units: 0, **kwargs)
@@ -116,5 +116,334 @@ module MXNet::Gluon::NN
   end
   def self.Dense(*args)
     Dense.new(*args)
+  end
+  module Internal
+    ##
+    # Base class for convolution layers.
+    #
+    # This layer creates a convolution kernel that is convolved with
+    # the input to produce a tensor of outputs.
+    #
+    class Conv < MXNet::Gluon::HybridBlock
+      ##
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +channels+::    (integer)
+      #                 The dimensionality of the output space (the
+      #                 number of output channels in the convolution).
+      # +kernel_size+:: (array of N integers)
+      #                 Specifies the dimensions of the convolution
+      #                 window.
+      # +strides+::     (integer or array of N integers)
+      #                 Specifies the strides of the convolution.
+      # +padding+::     (integer or array of N integers)
+      #                 If padding is non-zero, then the input is
+      #                 implicitly zero-padded on both sides for
+      #                 +padding+ number of points.
+      # +dilation+::    (integer or array of N integers)
+      #                 Specifies the dilation rate to use for dilated
+      #                 convolution.
+      # +layout+::      (string)
+      #                 Dimension ordering of data and weight. Can be
+      #                 'NCW', 'NWC', 'NCHW', 'NHWC', 'NCDHW', 'NDHWC',
+      #                 etc. 'N', 'C', 'H', 'W', 'D' stands for batch,
+      #                 channel, height, width and depth dimensions
+      #                 respectively. Convolution is performed over
+      #                 'D', 'H', and 'W' dimensions.
+      # +in_channels+:: (integer, default 0)
+      #                 The number of input channels to this layer. If
+      #                 not specified, initialization will be deferred
+      #                 to the first time #forward is called and
+      #                 +in_channels+ will be inferred from the shape
+      #                 of the input data.
+      # +use_bias+::    (boolean, default +true+)
+      #                 Whether the layer uses a bias vector.
+      # +activation+::  (string, optional)
+      #                 Activation function to use. If nothing is
+      #                 specified, no activation is applied (it acts
+      #                 like "linear" activation: <tt>a(x) = x</tt>).
+      # +prefix+::      (string, optional)
+      #                 Name space for child blocks.
+      # +params+::      (ParameterDict, optional)
+      #                 ParameterDict for sharing weights.
+      #
+      def initialize(channels:, kernel_size:, strides:, padding:, dilation:,
+                     layout:, in_channels: 0, use_bias: true, activation: nil,
+                     op_name: 'Convolution', prefix: nil, params: nil)
+        super(prefix: prefix, params: params)
+        self.with_name_scope do
+          @channels = channels
+          @in_channels = in_channels
+          if strides.is_a?(Numeric)
+            strides = [strides] * kernel_size.length
+          end
+          if padding.is_a?(Numeric)
+            padding = [padding] * kernel_size.length
+          end
+          if dilation.is_a?(Numeric)
+            dilation = [dilation] * kernel_size.length
+          end
+          @op_name = op_name
+          @kwargs = {
+            kernel: kernel_size,
+            stride: strides,
+            pad: padding,
+            dilate: dilation,
+            no_bias: !use_bias,
+            num_filter: channels,
+            layout: layout
+          }
+          shape = [0] * (kernel_size.length + 2)
+          shape[layout.index('C')] = in_channels
+          shape[layout.index('N')] = 1
+          _, wshape, bshape = infer_weight_shape(@op_name, shape, @kwargs)
+          self.weight = self.params.get(
+            'weight',
+            shape: wshape,
+            allow_deferred_init: true
+          )
+          if use_bias
+            self.bias = self.params.get(
+              'bias',
+              shape: bshape,
+              allow_deferred_init: true
+            )
+          else
+            self.bias = nil
+          end
+          if activation
+            self.act = MXNet::Gluon::NN.Activation(
+              activation,
+              prefix: "#{activation}_"
+            )
+          else
+            self.act = nil
+          end
+        end
+      end
+      def hybrid_forward(clazz, data, weight = nil, bias = nil, **kwargs)
+        weight ||= kwargs[:weight]
+        bias ||= kwargs[:bias]
+        if bias.nil?
+          out = clazz.send(@op_name, data, weight, **@kwargs)
+        else
+          out = clazz.send(@op_name, data, weight, bias, **@kwargs)
+        end
+        if self.act
+          out = self.act[out]
+        end
+        out
+      end
+      private
+      def infer_weight_shape(op_name, shape, **kwargs)
+        sym = MXNet::Symbol.var('data', shape: shape)
+        sym = MXNet::Symbol.send(op_name, sym, **kwargs)
+        sym.infer_shape_partial[0]
+      end
+      def hint
+        'conv'
+      end
+    end
+    ##
+    # Base class for pooling layers.
+    #
+    class Pooling < MXNet::Gluon::HybridBlock
+      ##
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +pool_size+::   (array of N integers)
+      #                 Specifies the dimensions of pooling
+      #                 operation.
+      # +strides+::     (integer or array of N integers)
+      #                 Specifies the strides of the pooling
+      #                 operation.
+      # +padding+::     (integer or array of N integers)
+      #                 If padding is non-zero, then the input is
+      #                 implicitly zero-padded on both sides for
+      #                 +padding+ number of points.
+      # +prefix+::      (string, optional)
+      #                 Name space for child blocks.
+      # +params+::      (ParameterDict, optional)
+      #                 ParameterDict for sharing weights.
+      #
+      def initialize(pool_size:, strides:, padding:,
+                     prefix: nil, params: nil)
+        super(prefix: prefix, params: params)
+        if strides.nil?
+          strides = pool_size
+        end
+        if strides.is_a?(Numeric)
+          strides = [strides] * pool_size.length
+        end
+        if padding.is_a?(Numeric)
+          padding = [padding] * pool_size.length
+        end
+        @kwargs = {
+          kernel: pool_size,
+          stride: strides,
+          pad: padding
+        }
+      end
+      def hybrid_forward(clazz, data)
+        clazz.Pooling(data, **@kwargs)
+      end
+      private
+      def hint
+        'pool'
+      end
+    end
+  end
+  ##
+  # 2D convolution layer (e.g. spatial convolution over images).
+  #
+  # This layer creates a convolution kernel that is convolved with the
+  # input to produce a tensor of outputs. If +use_bias+ is +true+, a
+  # bias vector is created and added to the outputs.  Finally, if
+  # +activation+ is not +nil+, the activation is applied to the
+  # outputs. If +in_channels+ is not specified, parameter
+  # initialization will be deferred to the first time #forward is
+  # called and +in_channels+ will be inferred from the shape of input
+  # data.
+  #
+  class Conv2D < MXNet::Gluon::NN::Internal::Conv
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +channels+::    (integer)
+    #                 The dimensionality of the output space (the
+    #                 number of output channels in the convolution).
+    # +kernel_size+:: (integer or array of 2 integers)
+    #                 Specifies the size of the convolution window.
+    # +strides+::     (integer or array of 2 integers, default 1)
+    #                 Specifies the strides of the convolution.
+    # +padding+::     (integer or array of 2 integers, default 0)
+    #                 If padding is non-zero, then the input is
+    #                 implicitly zero-padded on both sides for
+    #                 +padding+ number of points.
+    # +dilation+::    (integer or array of 2 integers, default 1)
+    #                 Specifies the dilation rate to use for dilated
+    #                 convolution.
+    # +layout+::      (string, default 'NCHW')
+    #                 Dimension ordering of data and weight. Only
+    #                 supports 'NCHW' and 'NHWC' layout for now. 'N',
+    #                 'C', 'H', 'W' stands for batch, channel, height,
+    #                 and width dimensions respectively. Convolution
+    #                 is applied on the 'H' and 'W' dimensions.
+    # +in_channels+:: (integer, default 0)
+    #                 The number of input channels to this layer. If
+    #                 not specified, initialization will be deferred
+    #                 to the first time #forward is called and
+    #                 +in_channels+ will be inferred from the shape
+    #                 of the input data.
+    # +use_bias+::    (boolean, default +true+)
+    #                 Whether the layer uses a bias vector.
+    # +activation+::  (string, optional)
+    #                 Activation function to use. If nothing is
+    #                 specified, no activation is applied (it acts
+    #                 like "linear" activation: <tt>a(x) = x</tt>).
+    # +prefix+::      (string, optional)
+    #                 Name space for child blocks.
+    # +params+::      (ParameterDict, optional)
+    #                 ParameterDict for sharing weights.
+    #
+    def initialize(channels:, kernel_size:, strides: 1, padding: 0, dilation: 1,
+                   layout: 'NCHW', in_channels: 0, use_bias: true, activation: nil,
+                   prefix: nil, params: nil)
+      if kernel_size.is_a?(Numeric)
+        kernel_size = [kernel_size] * 2
+      end
+      unless kernel_size.length == 2
+        raise ArgumentError, "kernel_size must be an integer or an array of 2 integers"
+      end
+      super(
+        channels: channels,
+        kernel_size: kernel_size,
+        strides: strides,
+        padding: padding,
+        dilation: dilation,
+        layout: layout,
+        in_channels: in_channels,
+        use_bias: use_bias,
+        activation: activation,
+        prefix: prefix,
+        params: params
+      )
+    end
+  end
+  def self.Conv2D(*args)
+    Conv2D.new(*args)
+  end
+  ##
+  # Max pooling operation for 2D data (e.g. images).
+  #
+  class MaxPool2D < MXNet::Gluon::NN::Internal::Pooling
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +pool_size+::   (integer or array of 2 integers, default 2)
+    #                 Specifies the size of pooling window.
+    # +strides+::     (integer or array of 2 integers, default +nil+)
+    #                 Specifies the strides of the pooling operation.
+    # +padding+::     (integer or array of 2 integers, default 0)
+    #                 If padding is non-zero, then the input is
+    #                 implicitly zero-padded on both sides for
+    #                 +padding+ number of points.
+    # +prefix+::      (string, optional)
+    #                 Name space for child blocks.
+    # +params+::      (ParameterDict, optional)
+    #                 ParameterDict for sharing weights.
+    #
+    def initialize(pool_size: 2, strides: nil, padding: 0,
+                   prefix: nil, params: nil)
+      if pool_size.is_a?(Numeric)
+        pool_size = [pool_size] * 2
+      end
+      unless pool_size.length == 2
+        raise ArgumentError, "pool_size must be an integer or an array of 2 integers"
+      end
+      super(
+        pool_size: pool_size,
+        strides: strides,
+        padding: padding,
+        prefix: prefix,
+        params: params
+      )
+    end
+  end
+  def self.MaxPool2D(*args)
+    MaxPool2D.new(*args)
+  end
+  ##
+  # Flattens the input to two dimensions.
+  #
+  # ====Inputs
+  #
+  # Tensor with arbitrary shape: <tt>[N, x1, x2, ..., xn]</tt>
+  #
+  # ====Output
+  #
+  # Tensor with shape: <tt>[N, x1 * x2 * ... * xn]</tt>
+  #
+  class Flatten < MXNet::Gluon::HybridBlock
+    ##
+    # Creates a new instance.
+    #
+    def initialize(**kwargs)
+      super(**kwargs)
+    end
+    def hybrid_forward(clazz, data)
+      clazz.flatten(data)
+    end
+  end
+  def self.Flatten(*args)
+    Flatten.new(*args)
   end
 end

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -57,10 +57,5 @@ module MXNet::Gluon::NN
       bias ||= kwargs[:bias]
       clazz.FullyConnected(data, weight, bias, no_bias: bias.nil?, num_hidden: @units)
     end
-    private
-    def deferred_infer_shape(*args)
-      # FIXME: for now, punted to the subclass
-      self.weight.shape = [@units, args.first.shape[1]]
-    end
   end
 end

--- a/lib/mxnet/gluon/nn/layers.rb
+++ b/lib/mxnet/gluon/nn/layers.rb
@@ -1,533 +1,537 @@
 require 'mxnet/gluon/block'
 require 'mxnet/gluon/nn'
 
-module MXNet::Gluon::NN
-  ##
-  # Stacks blocks sequentially.
-  #
-  #     net = MXNet::Gluon::NN.Sequential
-  #     net.with_name_scope do
-  #       net.add(MXNet::Gluon::NN.Dense(10, activation: :relu))
-  #       net.add(MXNet::Gluon::NN.Dense(20))
-  #     end
-  #
-  class Sequential < MXNet::Gluon::Block
-    ##
-    # Creates a new instance.
-    #
-    def initialize(**kwargs)
-      super(**kwargs)
-    end
-
-    ##
-    # Adds blocks on top of the stack.
-    #
-    def add(*blocks)
-      blocks.each { |block| register_child(block) }
-    end
-
-    ##
-    # Returns the number of blocks in the sequential stack.
-    #
-    def length
-      children.length
-    end
-
-    ##
-    # Returns the block at the specified index.
-    #
-    def at(index)
-      children[index]
-    end
-
-    ##
-    # Runs a forward pass on all child blocks.
-    #
-    def forward(data)
-      children.inject(data) { |data, child| child.forward(data) }
-    end
-  end
-
-  def self.Sequential(*args)
-    Sequential.new(*args)
-  end
-
-  ##
-  # Stacks HybridBlocks sequentially.
-  #
-  #     net = MXNet::Gluon::NN.HybridSequential
-  #     net.with_name_scope do
-  #       net.add(MXNet::Gluon::NN.Dense(10, activation: :relu))
-  #       net.add(MXNet::Gluon::NN.Dense(20))
-  #     end
-  #     net.hybridize
-  #
-  class HybridSequential < MXNet::Gluon::HybridBlock
-    ##
-    # Creates a new instance.
-    #
-    def initialize(**kwargs)
-      super(**kwargs)
-    end
-
-    ##
-    # Adds blocks on top of the stack.
-    #
-    def add(*blocks)
-      blocks.each { |block| register_child(block) }
-    end
-
-    ##
-    # Returns the number of blocks in the sequential stack.
-    #
-    def length
-      children.length
-    end
-
-    ##
-    # Returns the block at the specified index.
-    #
-    def at(index)
-      children[index]
-    end
-
-    ##
-    # Runs a forward pass on all child blocks.
-    #
-    def hybrid_forward(clazz, data)
-      children.inject(data) { |data, child| child.forward(data) }
-    end
-  end
-
-  def self.HybridSequential(*args)
-    HybridSequential.new(*args)
-  end
-
-  ##
-  # Just your regular densely-connected neural network layer.
-  #
-  # Implements the operation:
-  #
-  #     output = activation(dot(input, weight) + bias)
-  #
-  # where +activation+ is the element-wise activation function passed
-  # as the +activation+ argument, +weight+ is a weights matrix created
-  # by the layer, and +bias+ is a bias vector created by the layer
-  # (if argument +use_bias+ is +true+).
-  #
-  # Note: +input+ must be a tensor with rank two. Use
-  # MXNet::NDArray#flatten to convert it to rank two if necessary.
-  #
-  class Dense < MXNet::Gluon::HybridBlock
-    ##
-    # Creates a new instance.
-    #
-    # ====Parameters
-    #
-    # +units_::      (integer)
-    #                Dimensionality of the output space.
-    # +use_bias+::   (boolean, default +true+)
-    #                Whether the layer uses a bias vector.
-    # +activation+:: (string, optional)
-    #                Activation function to use. If nothing is
-    #                specified, no activation is applied (it acts like
-    #                "linear" activation: <tt>a(x) = x</tt>).
-    # +in_units+::   (integer, optional)
-    #                Size of the input data. If not specified,
-    #                initialization will be deferred to the first time
-    #                #forward is called and +in_units+ will be
-    #                inferred from the shape of input data.
-    #
-    def initialize(units, use_bias: true, activation: nil, in_units: 0, **kwargs)
-      super(**kwargs)
-      self.with_name_scope do
-        @units = units
-        @in_units = in_units
-        self.weight = params.get(
-          'weight',
-          shape: [units, in_units],
-          init: nil,
-          allow_deferred_init: true
-        )
-        if use_bias
-          self.bias = params.get(
-            'bias',
-            shape: [units],
-            init: :zeros,
-            allow_deferred_init: true
-          )
-        else
-          self.bias = nil
-        end
-        if activation
-          self.act = MXNet::Gluon::NN.Activation(
-            activation,
-            prefix: "#{activation}_"
-          )
-        else
-          self.act = nil
-        end
-      end
-    end
-
-    def hybrid_forward(clazz, data, weight:, bias: nil)
-      out = clazz.FullyConnected(
-        data,
-        weight,
-        bias,
-        no_bias: bias.nil?,
-        num_hidden: @units
-      )
-      if self.act
-        out = self.act[out]
-      end
-      out
-    end
-  end
-
-  def self.Dense(*args)
-    Dense.new(*args)
-  end
-
-  module Internal
-    ##
-    # Base class for convolution layers.
-    #
-    # This layer creates a convolution kernel that is convolved with
-    # the input to produce a tensor of outputs.
-    #
-    class Conv < MXNet::Gluon::HybridBlock
+module MXNet
+  module Gluon
+    module NN
       ##
-      # Creates a new instance.
+      # Stacks blocks sequentially.
       #
-      # ====Parameters
+      #     net = MXNet::Gluon::NN.Sequential
+      #     net.with_name_scope do
+      #       net.add(MXNet::Gluon::NN.Dense(10, activation: :relu))
+      #       net.add(MXNet::Gluon::NN.Dense(20))
+      #     end
       #
-      # +channels+::    (integer)
-      #                 The dimensionality of the output space (the
-      #                 number of output channels in the convolution).
-      # +kernel_size+:: (array of N integers)
-      #                 Specifies the dimensions of the convolution
-      #                 window.
-      # +strides+::     (integer or array of N integers)
-      #                 Specifies the strides of the convolution.
-      # +padding+::     (integer or array of N integers)
-      #                 If padding is non-zero, then the input is
-      #                 implicitly zero-padded on both sides for
-      #                 +padding+ number of points.
-      # +dilation+::    (integer or array of N integers)
-      #                 Specifies the dilation rate to use for dilated
-      #                 convolution.
-      # +layout+::      (string)
-      #                 Dimension ordering of data and weight. Can be
-      #                 'NCW', 'NWC', 'NCHW', 'NHWC', 'NCDHW', 'NDHWC',
-      #                 etc. 'N', 'C', 'H', 'W', 'D' stands for batch,
-      #                 channel, height, width and depth dimensions
-      #                 respectively. Convolution is performed over
-      #                 'D', 'H', and 'W' dimensions.
-      # +in_channels+:: (integer, default 0)
-      #                 The number of input channels to this layer. If
-      #                 not specified, initialization will be deferred
-      #                 to the first time #forward is called and
-      #                 +in_channels+ will be inferred from the shape
-      #                 of the input data.
-      # +use_bias+::    (boolean, default +true+)
-      #                 Whether the layer uses a bias vector.
-      # +activation+::  (string, optional)
-      #                 Activation function to use. If nothing is
-      #                 specified, no activation is applied (it acts
-      #                 like "linear" activation: <tt>a(x) = x</tt>).
-      # +prefix+::      (string, optional)
-      #                 Name space for child blocks.
-      # +params+::      (ParameterDict, optional)
-      #                 ParameterDict for sharing weights.
+      class Sequential < MXNet::Gluon::Block
+        ##
+        # Creates a new instance.
+        #
+        def initialize(**kwargs)
+          super(**kwargs)
+        end
+
+        ##
+        # Adds blocks on top of the stack.
+        #
+        def add(*blocks)
+          blocks.each { |block| register_child(block) }
+        end
+
+        ##
+        # Returns the number of blocks in the sequential stack.
+        #
+        def length
+          children.length
+        end
+
+        ##
+        # Returns the block at the specified index.
+        #
+        def at(index)
+          children[index]
+        end
+
+        ##
+        # Runs a forward pass on all child blocks.
+        #
+        def forward(data)
+          children.inject(data) { |data, child| child.forward(data) }
+        end
+      end
+
+      def self.Sequential(*args)
+        Sequential.new(*args)
+      end
+
+      ##
+      # Stacks HybridBlocks sequentially.
       #
-      def initialize(channels:, kernel_size:, strides:, padding:, dilation:,
-                     layout:, in_channels: 0, use_bias: true, activation: nil,
-                     op_name: 'Convolution', prefix: nil, params: nil)
-        super(prefix: prefix, params: params)
-        self.with_name_scope do
-          @channels = channels
-          @in_channels = in_channels
-          if strides.is_a?(Numeric)
-            strides = [strides] * kernel_size.length
-          end
-          if padding.is_a?(Numeric)
-            padding = [padding] * kernel_size.length
-          end
-          if dilation.is_a?(Numeric)
-            dilation = [dilation] * kernel_size.length
-          end
-          @op_name = op_name
-          @kwargs = {
-            kernel: kernel_size,
-            stride: strides,
-            pad: padding,
-            dilate: dilation,
-            no_bias: !use_bias,
-            num_filter: channels,
-            layout: layout
-          }
-          shape = [0] * (kernel_size.length + 2)
-          shape[layout.index('C')] = in_channels
-          shape[layout.index('N')] = 1
-          _, wshape, bshape = infer_weight_shape(@op_name, shape, @kwargs)
-          self.weight = self.params.get(
-            'weight',
-            shape: wshape,
-            init: nil,
-            allow_deferred_init: true
-          )
-          if use_bias
-            self.bias = self.params.get(
-              'bias',
-              shape: bshape,
-              init: :zeros,
+      #     net = MXNet::Gluon::NN.HybridSequential
+      #     net.with_name_scope do
+      #       net.add(MXNet::Gluon::NN.Dense(10, activation: :relu))
+      #       net.add(MXNet::Gluon::NN.Dense(20))
+      #     end
+      #     net.hybridize
+      #
+      class HybridSequential < MXNet::Gluon::HybridBlock
+        ##
+        # Creates a new instance.
+        #
+        def initialize(**kwargs)
+          super(**kwargs)
+        end
+
+        ##
+        # Adds blocks on top of the stack.
+        #
+        def add(*blocks)
+          blocks.each { |block| register_child(block) }
+        end
+
+        ##
+        # Returns the number of blocks in the sequential stack.
+        #
+        def length
+          children.length
+        end
+
+        ##
+        # Returns the block at the specified index.
+        #
+        def at(index)
+          children[index]
+        end
+
+        ##
+        # Runs a forward pass on all child blocks.
+        #
+        def hybrid_forward(clazz, data)
+          children.inject(data) { |data, child| child.forward(data) }
+        end
+      end
+
+      def self.HybridSequential(*args)
+        HybridSequential.new(*args)
+      end
+
+      ##
+      # Just your regular densely-connected neural network layer.
+      #
+      # Implements the operation:
+      #
+      #     output = activation(dot(input, weight) + bias)
+      #
+      # where +activation+ is the element-wise activation function passed
+      # as the +activation+ argument, +weight+ is a weights matrix created
+      # by the layer, and +bias+ is a bias vector created by the layer
+      # (if argument +use_bias+ is +true+).
+      #
+      # Note: +input+ must be a tensor with rank two. Use
+      # MXNet::NDArray#flatten to convert it to rank two if necessary.
+      #
+      class Dense < MXNet::Gluon::HybridBlock
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +units_::      (integer)
+        #                Dimensionality of the output space.
+        # +use_bias+::   (boolean, default +true+)
+        #                Whether the layer uses a bias vector.
+        # +activation+:: (string, optional)
+        #                Activation function to use. If nothing is
+        #                specified, no activation is applied (it acts like
+        #                "linear" activation: <tt>a(x) = x</tt>).
+        # +in_units+::   (integer, optional)
+        #                Size of the input data. If not specified,
+        #                initialization will be deferred to the first time
+        #                #forward is called and +in_units+ will be
+        #                inferred from the shape of input data.
+        #
+        def initialize(units, use_bias: true, activation: nil, in_units: 0, **kwargs)
+          super(**kwargs)
+          self.with_name_scope do
+            @units = units
+            @in_units = in_units
+            self.weight = params.get(
+              'weight',
+              shape: [units, in_units],
+              init: nil,
               allow_deferred_init: true
             )
-          else
-            self.bias = nil
+            if use_bias
+              self.bias = params.get(
+                'bias',
+                shape: [units],
+                init: :zeros,
+                allow_deferred_init: true
+              )
+            else
+              self.bias = nil
+            end
+            if activation
+              self.act = MXNet::Gluon::NN.Activation(
+                activation,
+                prefix: "#{activation}_"
+              )
+            else
+              self.act = nil
+            end
           end
-          if activation
-            self.act = MXNet::Gluon::NN.Activation(
-              activation,
-              prefix: "#{activation}_"
-            )
-          else
-            self.act = nil
+        end
+
+        def hybrid_forward(clazz, data, weight:, bias: nil)
+          out = clazz.FullyConnected(
+            data,
+            weight,
+            bias,
+            no_bias: bias.nil?,
+            num_hidden: @units
+          )
+          if self.act
+            out = self.act[out]
+          end
+          out
+        end
+      end
+
+      def self.Dense(*args)
+        Dense.new(*args)
+      end
+
+      module Internal
+        ##
+        # Base class for convolution layers.
+        #
+        # This layer creates a convolution kernel that is convolved with
+        # the input to produce a tensor of outputs.
+        #
+        class Conv < MXNet::Gluon::HybridBlock
+          ##
+          # Creates a new instance.
+          #
+          # ====Parameters
+          #
+          # +channels+::    (integer)
+          #                 The dimensionality of the output space (the
+          #                 number of output channels in the convolution).
+          # +kernel_size+:: (array of N integers)
+          #                 Specifies the dimensions of the convolution
+          #                 window.
+          # +strides+::     (integer or array of N integers)
+          #                 Specifies the strides of the convolution.
+          # +padding+::     (integer or array of N integers)
+          #                 If padding is non-zero, then the input is
+          #                 implicitly zero-padded on both sides for
+          #                 +padding+ number of points.
+          # +dilation+::    (integer or array of N integers)
+          #                 Specifies the dilation rate to use for dilated
+          #                 convolution.
+          # +layout+::      (string)
+          #                 Dimension ordering of data and weight. Can be
+          #                 'NCW', 'NWC', 'NCHW', 'NHWC', 'NCDHW', 'NDHWC',
+          #                 etc. 'N', 'C', 'H', 'W', 'D' stands for batch,
+          #                 channel, height, width and depth dimensions
+          #                 respectively. Convolution is performed over
+          #                 'D', 'H', and 'W' dimensions.
+          # +in_channels+:: (integer, default 0)
+          #                 The number of input channels to this layer. If
+          #                 not specified, initialization will be deferred
+          #                 to the first time #forward is called and
+          #                 +in_channels+ will be inferred from the shape
+          #                 of the input data.
+          # +use_bias+::    (boolean, default +true+)
+          #                 Whether the layer uses a bias vector.
+          # +activation+::  (string, optional)
+          #                 Activation function to use. If nothing is
+          #                 specified, no activation is applied (it acts
+          #                 like "linear" activation: <tt>a(x) = x</tt>).
+          # +prefix+::      (string, optional)
+          #                 Name space for child blocks.
+          # +params+::      (ParameterDict, optional)
+          #                 ParameterDict for sharing weights.
+          #
+          def initialize(channels:, kernel_size:, strides:, padding:, dilation:,
+                         layout:, in_channels: 0, use_bias: true, activation: nil,
+                         op_name: 'Convolution', prefix: nil, params: nil)
+            super(prefix: prefix, params: params)
+            self.with_name_scope do
+              @channels = channels
+              @in_channels = in_channels
+              if strides.is_a?(Numeric)
+                strides = [strides] * kernel_size.length
+              end
+              if padding.is_a?(Numeric)
+                padding = [padding] * kernel_size.length
+              end
+              if dilation.is_a?(Numeric)
+                dilation = [dilation] * kernel_size.length
+              end
+              @op_name = op_name
+              @kwargs = {
+                kernel: kernel_size,
+                stride: strides,
+                pad: padding,
+                dilate: dilation,
+                no_bias: !use_bias,
+                num_filter: channels,
+                layout: layout
+              }
+              shape = [0] * (kernel_size.length + 2)
+              shape[layout.index('C')] = in_channels
+              shape[layout.index('N')] = 1
+              _, wshape, bshape = infer_weight_shape(@op_name, shape, @kwargs)
+              self.weight = self.params.get(
+                'weight',
+                shape: wshape,
+                init: nil,
+                allow_deferred_init: true
+              )
+              if use_bias
+                self.bias = self.params.get(
+                  'bias',
+                  shape: bshape,
+                  init: :zeros,
+                  allow_deferred_init: true
+                )
+              else
+                self.bias = nil
+              end
+              if activation
+                self.act = MXNet::Gluon::NN.Activation(
+                  activation,
+                  prefix: "#{activation}_"
+                )
+              else
+                self.act = nil
+              end
+            end
+          end
+
+          def hybrid_forward(clazz, data, weight:, bias: nil)
+            kwargs = @kwargs.merge(no_bias: bias.nil?)
+            out = clazz.send(@op_name, data, weight, bias, **kwargs)
+            if self.act
+              out = self.act[out]
+            end
+            out
+          end
+
+          private
+
+          def infer_weight_shape(op_name, shape, **kwargs)
+            sym = MXNet::Symbol.var('data', shape: shape)
+            sym = MXNet::Symbol.send(op_name, sym, **kwargs)
+            sym.infer_shape_partial[0]
+          end
+
+          def hint
+            'conv'
+          end
+        end
+
+        ##
+        # Base class for pooling layers.
+        #
+        class Pooling < MXNet::Gluon::HybridBlock
+          ##
+          # Creates a new instance.
+          #
+          # ====Parameters
+          #
+          # +pool_size+::   (array of N integers)
+          #                 Specifies the dimensions of pooling
+          #                 operation.
+          # +strides+::     (integer or array of N integers)
+          #                 Specifies the strides of the pooling
+          #                 operation.
+          # +padding+::     (integer or array of N integers)
+          #                 If padding is non-zero, then the input is
+          #                 implicitly zero-padded on both sides for
+          #                 +padding+ number of points.
+          # +prefix+::      (string, optional)
+          #                 Name space for child blocks.
+          # +params+::      (ParameterDict, optional)
+          #                 ParameterDict for sharing weights.
+          #
+          def initialize(pool_size:, strides:, padding:,
+                         prefix: nil, params: nil)
+            super(prefix: prefix, params: params)
+            if strides.nil?
+              strides = pool_size
+            end
+            if strides.is_a?(Numeric)
+              strides = [strides] * pool_size.length
+            end
+            if padding.is_a?(Numeric)
+              padding = [padding] * pool_size.length
+            end
+            @kwargs = {
+              kernel: pool_size,
+              stride: strides,
+              pad: padding
+            }
+          end
+
+          def hybrid_forward(clazz, data)
+            clazz.Pooling(data, **@kwargs)
+          end
+
+          private
+
+          def hint
+            'pool'
           end
         end
       end
 
-      def hybrid_forward(clazz, data, weight:, bias: nil)
-        kwargs = @kwargs.merge(no_bias: bias.nil?)
-        out = clazz.send(@op_name, data, weight, bias, **kwargs)
-        if self.act
-          out = self.act[out]
-        end
-        out
-      end
-
-      private
-
-      def infer_weight_shape(op_name, shape, **kwargs)
-        sym = MXNet::Symbol.var('data', shape: shape)
-        sym = MXNet::Symbol.send(op_name, sym, **kwargs)
-        sym.infer_shape_partial[0]
-      end
-
-      def hint
-        'conv'
-      end
-    end
-
-    ##
-    # Base class for pooling layers.
-    #
-    class Pooling < MXNet::Gluon::HybridBlock
       ##
-      # Creates a new instance.
+      # 2D convolution layer (e.g. spatial convolution over images).
       #
-      # ====Parameters
+      # This layer creates a convolution kernel that is convolved with the
+      # input to produce a tensor of outputs. If +use_bias+ is +true+, a
+      # bias vector is created and added to the outputs.  Finally, if
+      # +activation+ is not +nil+, the activation is applied to the
+      # outputs. If +in_channels+ is not specified, parameter
+      # initialization will be deferred to the first time #forward is
+      # called and +in_channels+ will be inferred from the shape of input
+      # data.
       #
-      # +pool_size+::   (array of N integers)
-      #                 Specifies the dimensions of pooling
-      #                 operation.
-      # +strides+::     (integer or array of N integers)
-      #                 Specifies the strides of the pooling
-      #                 operation.
-      # +padding+::     (integer or array of N integers)
-      #                 If padding is non-zero, then the input is
-      #                 implicitly zero-padded on both sides for
-      #                 +padding+ number of points.
-      # +prefix+::      (string, optional)
-      #                 Name space for child blocks.
-      # +params+::      (ParameterDict, optional)
-      #                 ParameterDict for sharing weights.
+      class Conv2D < MXNet::Gluon::NN::Internal::Conv
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +channels+::    (integer)
+        #                 The dimensionality of the output space (the
+        #                 number of output channels in the convolution).
+        # +kernel_size+:: (integer or array of 2 integers)
+        #                 Specifies the size of the convolution window.
+        # +strides+::     (integer or array of 2 integers, default 1)
+        #                 Specifies the strides of the convolution.
+        # +padding+::     (integer or array of 2 integers, default 0)
+        #                 If padding is non-zero, then the input is
+        #                 implicitly zero-padded on both sides for
+        #                 +padding+ number of points.
+        # +dilation+::    (integer or array of 2 integers, default 1)
+        #                 Specifies the dilation rate to use for dilated
+        #                 convolution.
+        # +layout+::      (string, default 'NCHW')
+        #                 Dimension ordering of data and weight. Only
+        #                 supports 'NCHW' and 'NHWC' layout for now. 'N',
+        #                 'C', 'H', 'W' stands for batch, channel, height,
+        #                 and width dimensions respectively. Convolution
+        #                 is applied on the 'H' and 'W' dimensions.
+        # +in_channels+:: (integer, default 0)
+        #                 The number of input channels to this layer. If
+        #                 not specified, initialization will be deferred
+        #                 to the first time #forward is called and
+        #                 +in_channels+ will be inferred from the shape
+        #                 of the input data.
+        # +use_bias+::    (boolean, default +true+)
+        #                 Whether the layer uses a bias vector.
+        # +activation+::  (string, optional)
+        #                 Activation function to use. If nothing is
+        #                 specified, no activation is applied (it acts
+        #                 like "linear" activation: <tt>a(x) = x</tt>).
+        # +prefix+::      (string, optional)
+        #                 Name space for child blocks.
+        # +params+::      (ParameterDict, optional)
+        #                 ParameterDict for sharing weights.
+        #
+        def initialize(channels:, kernel_size:, strides: 1, padding: 0, dilation: 1,
+                       layout: 'NCHW', in_channels: 0, use_bias: true, activation: nil,
+                       prefix: nil, params: nil)
+          if kernel_size.is_a?(Numeric)
+            kernel_size = [kernel_size] * 2
+          end
+          unless kernel_size.length == 2
+            raise ArgumentError, "kernel_size must be an integer or an array of 2 integers"
+          end
+          super(
+            channels: channels,
+            kernel_size: kernel_size,
+            strides: strides,
+            padding: padding,
+            dilation: dilation,
+            layout: layout,
+            in_channels: in_channels,
+            use_bias: use_bias,
+            activation: activation,
+            prefix: prefix,
+            params: params
+          )
+        end
+      end
+
+      def self.Conv2D(*args)
+        Conv2D.new(*args)
+      end
+
+      ##
+      # Max pooling operation for 2D data (e.g. images).
       #
-      def initialize(pool_size:, strides:, padding:,
-                     prefix: nil, params: nil)
-        super(prefix: prefix, params: params)
-        if strides.nil?
-          strides = pool_size
+      class MaxPool2D < MXNet::Gluon::NN::Internal::Pooling
+        ##
+        # Creates a new instance.
+        #
+        # ====Parameters
+        #
+        # +pool_size+::   (integer or array of 2 integers, default 2)
+        #                 Specifies the size of pooling window.
+        # +strides+::     (integer or array of 2 integers, default +nil+)
+        #                 Specifies the strides of the pooling operation.
+        # +padding+::     (integer or array of 2 integers, default 0)
+        #                 If padding is non-zero, then the input is
+        #                 implicitly zero-padded on both sides for
+        #                 +padding+ number of points.
+        # +prefix+::      (string, optional)
+        #                 Name space for child blocks.
+        # +params+::      (ParameterDict, optional)
+        #                 ParameterDict for sharing weights.
+        #
+        def initialize(pool_size: 2, strides: nil, padding: 0,
+                       prefix: nil, params: nil)
+          if pool_size.is_a?(Numeric)
+            pool_size = [pool_size] * 2
+          end
+          unless pool_size.length == 2
+            raise ArgumentError, "pool_size must be an integer or an array of 2 integers"
+          end
+          super(
+            pool_size: pool_size,
+            strides: strides,
+            padding: padding,
+            prefix: prefix,
+            params: params
+          )
         end
-        if strides.is_a?(Numeric)
-          strides = [strides] * pool_size.length
+      end
+
+      def self.MaxPool2D(*args)
+        MaxPool2D.new(*args)
+      end
+
+      ##
+      # Flattens the input to two dimensions.
+      #
+      # ====Inputs
+      #
+      # Tensor with arbitrary shape: <tt>[N, x1, x2, ..., xn]</tt>
+      #
+      # ====Output
+      #
+      # Tensor with shape: <tt>[N, x1 * x2 * ... * xn]</tt>
+      #
+      class Flatten < MXNet::Gluon::HybridBlock
+        ##
+        # Creates a new instance.
+        #
+        def initialize(**kwargs)
+          super(**kwargs)
         end
-        if padding.is_a?(Numeric)
-          padding = [padding] * pool_size.length
+
+        def hybrid_forward(clazz, data)
+          clazz.flatten(data)
         end
-        @kwargs = {
-          kernel: pool_size,
-          stride: strides,
-          pad: padding
-        }
       end
 
-      def hybrid_forward(clazz, data)
-        clazz.Pooling(data, **@kwargs)
-      end
-
-      private
-
-      def hint
-        'pool'
+      def self.Flatten(*args)
+        Flatten.new(*args)
       end
     end
-  end
-
-  ##
-  # 2D convolution layer (e.g. spatial convolution over images).
-  #
-  # This layer creates a convolution kernel that is convolved with the
-  # input to produce a tensor of outputs. If +use_bias+ is +true+, a
-  # bias vector is created and added to the outputs.  Finally, if
-  # +activation+ is not +nil+, the activation is applied to the
-  # outputs. If +in_channels+ is not specified, parameter
-  # initialization will be deferred to the first time #forward is
-  # called and +in_channels+ will be inferred from the shape of input
-  # data.
-  #
-  class Conv2D < MXNet::Gluon::NN::Internal::Conv
-    ##
-    # Creates a new instance.
-    #
-    # ====Parameters
-    #
-    # +channels+::    (integer)
-    #                 The dimensionality of the output space (the
-    #                 number of output channels in the convolution).
-    # +kernel_size+:: (integer or array of 2 integers)
-    #                 Specifies the size of the convolution window.
-    # +strides+::     (integer or array of 2 integers, default 1)
-    #                 Specifies the strides of the convolution.
-    # +padding+::     (integer or array of 2 integers, default 0)
-    #                 If padding is non-zero, then the input is
-    #                 implicitly zero-padded on both sides for
-    #                 +padding+ number of points.
-    # +dilation+::    (integer or array of 2 integers, default 1)
-    #                 Specifies the dilation rate to use for dilated
-    #                 convolution.
-    # +layout+::      (string, default 'NCHW')
-    #                 Dimension ordering of data and weight. Only
-    #                 supports 'NCHW' and 'NHWC' layout for now. 'N',
-    #                 'C', 'H', 'W' stands for batch, channel, height,
-    #                 and width dimensions respectively. Convolution
-    #                 is applied on the 'H' and 'W' dimensions.
-    # +in_channels+:: (integer, default 0)
-    #                 The number of input channels to this layer. If
-    #                 not specified, initialization will be deferred
-    #                 to the first time #forward is called and
-    #                 +in_channels+ will be inferred from the shape
-    #                 of the input data.
-    # +use_bias+::    (boolean, default +true+)
-    #                 Whether the layer uses a bias vector.
-    # +activation+::  (string, optional)
-    #                 Activation function to use. If nothing is
-    #                 specified, no activation is applied (it acts
-    #                 like "linear" activation: <tt>a(x) = x</tt>).
-    # +prefix+::      (string, optional)
-    #                 Name space for child blocks.
-    # +params+::      (ParameterDict, optional)
-    #                 ParameterDict for sharing weights.
-    #
-    def initialize(channels:, kernel_size:, strides: 1, padding: 0, dilation: 1,
-                   layout: 'NCHW', in_channels: 0, use_bias: true, activation: nil,
-                   prefix: nil, params: nil)
-      if kernel_size.is_a?(Numeric)
-        kernel_size = [kernel_size] * 2
-      end
-      unless kernel_size.length == 2
-        raise ArgumentError, "kernel_size must be an integer or an array of 2 integers"
-      end
-      super(
-        channels: channels,
-        kernel_size: kernel_size,
-        strides: strides,
-        padding: padding,
-        dilation: dilation,
-        layout: layout,
-        in_channels: in_channels,
-        use_bias: use_bias,
-        activation: activation,
-        prefix: prefix,
-        params: params
-      )
-    end
-  end
-
-  def self.Conv2D(*args)
-    Conv2D.new(*args)
-  end
-
-  ##
-  # Max pooling operation for 2D data (e.g. images).
-  #
-  class MaxPool2D < MXNet::Gluon::NN::Internal::Pooling
-    ##
-    # Creates a new instance.
-    #
-    # ====Parameters
-    #
-    # +pool_size+::   (integer or array of 2 integers, default 2)
-    #                 Specifies the size of pooling window.
-    # +strides+::     (integer or array of 2 integers, default +nil+)
-    #                 Specifies the strides of the pooling operation.
-    # +padding+::     (integer or array of 2 integers, default 0)
-    #                 If padding is non-zero, then the input is
-    #                 implicitly zero-padded on both sides for
-    #                 +padding+ number of points.
-    # +prefix+::      (string, optional)
-    #                 Name space for child blocks.
-    # +params+::      (ParameterDict, optional)
-    #                 ParameterDict for sharing weights.
-    #
-    def initialize(pool_size: 2, strides: nil, padding: 0,
-                   prefix: nil, params: nil)
-      if pool_size.is_a?(Numeric)
-        pool_size = [pool_size] * 2
-      end
-      unless pool_size.length == 2
-        raise ArgumentError, "pool_size must be an integer or an array of 2 integers"
-      end
-      super(
-        pool_size: pool_size,
-        strides: strides,
-        padding: padding,
-        prefix: prefix,
-        params: params
-      )
-    end
-  end
-
-  def self.MaxPool2D(*args)
-    MaxPool2D.new(*args)
-  end
-
-  ##
-  # Flattens the input to two dimensions.
-  #
-  # ====Inputs
-  #
-  # Tensor with arbitrary shape: <tt>[N, x1, x2, ..., xn]</tt>
-  #
-  # ====Output
-  #
-  # Tensor with shape: <tt>[N, x1 * x2 * ... * xn]</tt>
-  #
-  class Flatten < MXNet::Gluon::HybridBlock
-    ##
-    # Creates a new instance.
-    #
-    def initialize(**kwargs)
-      super(**kwargs)
-    end
-
-    def hybrid_forward(clazz, data)
-      clazz.flatten(data)
-    end
-  end
-
-  def self.Flatten(*args)
-    Flatten.new(*args)
   end
 end

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -12,14 +12,21 @@ module MXNet::Gluon
   # is initialized with #init. Also holds a gradient array on each
   # Context.
   #
-  # ====Parameters
-  #
-  # +name+::  (string) Name of this parameter.
-  # +shape+:: (integer or array of integers) Shape of this parameter.
-  #           By default shape is not specified.
-  #
   class Parameter
-    def initialize(name, shape: nil, dtype: :float32, allow_deferred_init: false)
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +name+::  (string)
+    #           Name of this parameter.
+    # +shape+:: (integer or array of integers)
+    #           Shape of this parameter.  By default, shape is not
+    #           specified.
+    # +dtype+:: (symbol or string, default +:float32+)
+    #           Data type of this parameter.
+    #
+    def initialize(name, shape: nil, dtype: :float32)
       @var = nil
       @name = name
       shape = [shape] if shape.is_a?(Integer)
@@ -139,7 +146,8 @@ module MXNet::Gluon
     #
     # ====Parameters
     #
-    # +ctx+:: (Context) Desired context.
+    # +ctx+:: (Context)
+    #         Desired context.
     #
     # ====Returns
     #
@@ -248,17 +256,22 @@ module MXNet::Gluon
   ##
   # A dictionary managing a set of Parameters.
   #
-  # ====Parameters
-  #
-  # +prefix+:: (string, default "") The prefix to be prepended to all
-  #            Parameters' names created by this dict.
-  # +shared+:: (ParameterDict or +nil+) If not +nil+, when this dict's
-  #            #get method creates a new parameter, will first try to
-  #            retrieve it from "shared" dict. Usually used for
-  #            sharing parameters with another Block.
-  #
   class ParameterDict
     include Enumerable
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +prefix+:: (string, default "")
+    #            The prefix to be prepended to all Parameters' names
+    #            created by this dict.
+    # +shared+:: (ParameterDict or +nil+)
+    #            If not +nil+, when this dict's #get method creates a
+    #            new parameter, will first try to retrieve it from
+    #            "shared" dict. Usually used for sharing parameters
+    #            with another Block.
+    #
     def initialize(prefix: '', shared: nil)
       @params = {}
       @prefix = prefix
@@ -288,8 +301,9 @@ module MXNet::Gluon
     #
     # ====Parameters
     #
-    # +name+:: (string) Name of the desired Parameter. It will be
-    #          prepended with this dict's prefix.
+    # +name+:: (string)
+    #          Name of the desired Parameter. It will be prepended
+    #          with this dict's prefix.
     #
     # ====Returns
     #
@@ -319,6 +333,8 @@ module MXNet::Gluon
     ##
     # Initializes all Parameters managed by this dict to be used for
     # NDArray API. It has no effect when using Symbol API.
+    #
+    # ====Parameters
     #
     # +init+::         (Initializer, default +nil+)
     #                  The initializer to use.

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -77,13 +77,13 @@ module MXNet::Gluon
     #                  arrays. Programmer is responsible for keeping
     #                  values consistent when updating. Normally
     #                  Trainer does this for you.
-    # +default_init+:: (Initializer, default MXNet::Uniform)
+    # +default_init+:: (Initializer, default `:uniform`)
     #                  Default initializer.
     # +force_reinit+:: (boolean, default false)
     #                  Whether to force re-initialization if parameter
     #                  is already initialized.
     #
-    def init(ctx: nil, default_init: MXNet::Uniform, force_reinit: false)
+    def init(ctx: nil, default_init: :uniform, force_reinit: false)
       unless @data.nil? || force_reinit
         return
       end
@@ -224,7 +224,7 @@ module MXNet::Gluon
       end
       MXNet::Autograd.pause do
         data = MXNet::NDArray.zeros(@shape, dtype: @dtype, ctx: MXNet.cpu)
-        default_init.new[data]
+        MXNet::Initializer.create(default_init)[data]
         @data = ctx.map { |c| data.copy_to(c) }
         grad = MXNet::NDArray.zeros(@shape, dtype: @dtype, ctx: MXNet.cpu)
         @grad = ctx.map { |c| grad.copy_to(c) }

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -1,497 +1,499 @@
 require 'mxnet/gluon'
 
-module MXNet::Gluon
-  ##
-  # Error for unfinished deferred initializations.
-  #
-  DeferredInitializationError = Class.new(RuntimeError)
-
-  ##
-  # A Container holding parameters (weights) of Blocks.
-  #
-  # Parameter holds a copy of the parameter on each Context after it
-  # is initialized with #init. If +grad_req+ is not `:null`, it also
-  # holds a gradient array on each Context.
-  #
-  class Parameter
+module MXNet
+  module Gluon
     ##
-    # Creates a new instance.
+    # Error for unfinished deferred initializations.
     #
-    # ====Parameters
+    DeferredInitializationError = Class.new(RuntimeError)
+
+    ##
+    # A Container holding parameters (weights) of Blocks.
     #
-    # +name+::                (string)
-    #                         Name of this parameter.
-    # +shape+::               (integer or array of integers)
-    #                         Shape of this parameter.  By default,
-    #                         shape is not specified.
-    # +dtype+::               (symbol or string, default +:float32+)
-    #                         Data type of this parameter.
-    # +init+::                (Initializer, default +nil+)
-    #                         The initializer to use.
-    # +allow_deferred_init+:: (boolean, default +false+)
-    #                         Is deferred initialization allowed.
-    # +grad_req+::            (+:write+|+:add+|+:null+, default: +:write+)
-    #                         Specifies how to update gradients.
-    #                         - +:write+ means update is written to
-    #                           the gradient.
-    #                         - +:add+ means update is added to the
-    #                           gradient. Call #zero_grad to clear the
-    #                           gradient when using this option.
-    #                         - +:null+ means a gradient is not
-    #                           supported on this parameter.
+    # Parameter holds a copy of the parameter on each Context after it
+    # is initialized with #init. If +grad_req+ is not `:null`, it also
+    # holds a gradient array on each Context.
     #
-    def initialize(name, shape: nil, dtype: :float32, init: nil,
-                   allow_deferred_init: false,
-                   grad_req: :write)
-      @var = nil
-      @name = name
-      shape = [shape] if shape.is_a?(Integer)
-      self.shape = shape
-      self.dtype = dtype
-      @init = init
-      @data = nil
-      @grad = nil
-      @deferred_init = []
-      @allow_deferred_init = allow_deferred_init
-      @grad_req = grad_req
-      @trainer = nil
-    end
+    class Parameter
+      ##
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +name+::                (string)
+      #                         Name of this parameter.
+      # +shape+::               (integer or array of integers)
+      #                         Shape of this parameter.  By default,
+      #                         shape is not specified.
+      # +dtype+::               (symbol or string, default +:float32+)
+      #                         Data type of this parameter.
+      # +init+::                (Initializer, default +nil+)
+      #                         The initializer to use.
+      # +allow_deferred_init+:: (boolean, default +false+)
+      #                         Is deferred initialization allowed.
+      # +grad_req+::            (+:write+|+:add+|+:null+, default: +:write+)
+      #                         Specifies how to update gradients.
+      #                         - +:write+ means update is written to
+      #                           the gradient.
+      #                         - +:add+ means update is added to the
+      #                           gradient. Call #zero_grad to clear the
+      #                           gradient when using this option.
+      #                         - +:null+ means a gradient is not
+      #                           supported on this parameter.
+      #
+      def initialize(name, shape: nil, dtype: :float32, init: nil,
+                     allow_deferred_init: false,
+                     grad_req: :write)
+        @var = nil
+        @name = name
+        shape = [shape] if shape.is_a?(Integer)
+        self.shape = shape
+        self.dtype = dtype
+        @init = init
+        @data = nil
+        @grad = nil
+        @deferred_init = []
+        @allow_deferred_init = allow_deferred_init
+        @grad_req = grad_req
+        @trainer = nil
+      end
 
-    def name
-      @name
-    end
+      def name
+        @name
+      end
 
-    def shape
-      @shape
-    end
+      def shape
+        @shape
+      end
 
-    def shape=(shape)
-      if @shape.nil?
-        @shape = shape
-      else
-        unless @shape.length == shape.length &&
-               @shape.zip(shape).all? { |i, j| i == j || i == 0 }
-          raise RuntimeError,
-                "Expected shape #{shape} is incompatible " \
-                "with given shape #{@shape}."
+      def shape=(shape)
+        if @shape.nil?
+          @shape = shape
+        else
+          unless @shape.length == shape.length &&
+                 @shape.zip(shape).all? { |i, j| i == j || i == 0 }
+            raise RuntimeError,
+                  "Expected shape #{shape} is incompatible " \
+                  "with given shape #{@shape}."
+          end
+          @shape = shape
         end
-        @shape = shape
       end
-    end
 
-    def dtype
-      @dtype
-    end
-
-    def dtype=(dtype)
-      @dtype = dtype.is_a?(::String) || dtype.is_a?(::Symbol) ?
-                 MXNet::DType.name2id(dtype) :
-                 dtype
-    end
-
-    def trainer
-      @trainer
-    end
-
-    def trainer=(trainer)
-      @trainer = trainer
-    end
-
-    ##
-    # Initializes parameter and gradient arrays. Only used for NDArray
-    # API.
-    #
-    # ====Parameters
-    #
-    # +init+::         (Initializer, default +nil+)
-    #                  The initializer to use. Overrides both `init`,
-    #                  set when this instance was created, and
-    #                  `default_init` in this call.
-    # +ctx+::          (Context or array of Contexts, default +nil+)
-    #                  Desired contexts. Initialize Parameter on given
-    #                  contexts. A copy will be made for each
-    #                  context. Note: copies are independent
-    #                  arrays. Programmer is responsible for keeping
-    #                  values consistent when updating. Normally
-    #                  Trainer does this for you.
-    # +default_init+:: (Initializer, default `:uniform`)
-    #                  Default initializer.
-    # +force_reinit+:: (boolean, default false)
-    #                  Whether to force re-initialization if parameter
-    #                  is already initialized.
-    #
-    # ====Examples
-    #
-    #     weight = MXNet::Gluon::Parameter.new('weight', shape: [2, 2])
-    #     weight.init(ctx: MXNet.cpu)
-    #     weight.data # => [[0.0068339, 0.0129982],...
-    #     weight.grad # => [[0, 0],...
-    #
-    def init(init: nil, ctx: nil, default_init: :uniform, force_reinit: false)
-      unless @data.nil? || force_reinit
-        return
+      def dtype
+        @dtype
       end
-      init = (@init || default_init) if init.nil?
-      ctx = [MXNet.current_context] if ctx.nil?
-      ctx = [ctx] if ctx.is_a?(MXNet::Context)
-      @ctx = ctx
-      @data = @grad = nil
-      if @shape.nil? || @shape.flatten.inject(&:*) <= 0
-        unless @allow_deferred_init
+
+      def dtype=(dtype)
+        @dtype = dtype.is_a?(::String) || dtype.is_a?(::Symbol) ?
+                   MXNet::DType.name2id(dtype) :
+                   dtype
+      end
+
+      def trainer
+        @trainer
+      end
+
+      def trainer=(trainer)
+        @trainer = trainer
+      end
+
+      ##
+      # Initializes parameter and gradient arrays. Only used for NDArray
+      # API.
+      #
+      # ====Parameters
+      #
+      # +init+::         (Initializer, default +nil+)
+      #                  The initializer to use. Overrides both `init`,
+      #                  set when this instance was created, and
+      #                  `default_init` in this call.
+      # +ctx+::          (Context or array of Contexts, default +nil+)
+      #                  Desired contexts. Initialize Parameter on given
+      #                  contexts. A copy will be made for each
+      #                  context. Note: copies are independent
+      #                  arrays. Programmer is responsible for keeping
+      #                  values consistent when updating. Normally
+      #                  Trainer does this for you.
+      # +default_init+:: (Initializer, default `:uniform`)
+      #                  Default initializer.
+      # +force_reinit+:: (boolean, default false)
+      #                  Whether to force re-initialization if parameter
+      #                  is already initialized.
+      #
+      # ====Examples
+      #
+      #     weight = MXNet::Gluon::Parameter.new('weight', shape: [2, 2])
+      #     weight.init(ctx: MXNet.cpu)
+      #     weight.data # => [[0.0068339, 0.0129982],...
+      #     weight.grad # => [[0, 0],...
+      #
+      def init(init: nil, ctx: nil, default_init: :uniform, force_reinit: false)
+        unless @data.nil? || force_reinit
+          return
+        end
+        init = (@init || default_init) if init.nil?
+        ctx = [MXNet.current_context] if ctx.nil?
+        ctx = [ctx] if ctx.is_a?(MXNet::Context)
+        @ctx = ctx
+        @data = @grad = nil
+        if @shape.nil? || @shape.flatten.inject(&:*) <= 0
+          unless @allow_deferred_init
+            raise RuntimeError,
+                  "Cannot initialize Parameter '#{@name}' because it has " \
+                  "invalid shape: #{@shape}."
+          end
+          @deferred_init = [ctx, init, nil]
+          return
+        end
+        @deferred_init = [ctx, init, nil]
+        finish_deferred_init
+      end
+
+      ##
+      # Returns a list of contexts this parameter is initialized on.
+      #
+      def list_ctx
+        if @data.nil?
+          unless @deferred_init.empty?
+            @deferred_init[0]
+          else
+            raise RuntimeError, "Parameter '#{@name}' has not been initialized."
+          end
+        else
+          @ctx
+        end
+      end
+
+      ##
+      # Returns a symbol representing this parameter.
+      #
+      def var
+        @var ||= MXNet::Symbol.var(@name, shape: @shape, dtype: @dtype)
+      end
+
+      ##
+      # Returns a copy of this parameter on one context. Must have been
+      # initialized on this context before.
+      #
+      # ====Parameters
+      #
+      # +ctx+:: (Context)
+      #         Desired context.
+      #
+      # ====Returns
+      #
+      # NDArray on context.
+      #
+      def data(ctx: nil)
+        check_and_get(@data, ctx)
+      end
+
+      ##
+      # Returns copies of this parameter on all contexts, in the same
+      # order as creation.
+      #
+      # ====Returns
+      #
+      # List of NDArrays.
+      #
+      def list_data
+        check_and_get(@data, :all)
+      end
+
+      ##
+      # Sets this parameter's value on all contexts.
+      #
+      def set_data(data)
+        @shape = data.shape
+        if @data
+          check_and_get(@data, :all).each do |arr|
+            arr[0..-1] = data
+          end
+        else
+          unless @deferred_init.empty?
+            @deferred_init[2] = data
+          else
+            raise RuntimeError, "Parameter '#{@name}' has not been initialized."
+          end
+        end
+      end
+
+      ##
+      # Returns a gradient buffer for this parameter on one context.
+      # Must have been initialized on this context before.
+      #
+      # ====Parameters
+      #
+      # +ctx+:: (Context) Desired context.
+      #
+      # ====Returns
+      #
+      # NDArray on context.
+      #
+      def grad(ctx: nil)
+        if !@grad && @data
+          raise RuntimeError,
+                "Cannot get gradient buffer for Parameter '#{name}' " \
+                "because grad_req=:null."
+        end
+        check_and_get(@grad, ctx)
+      end
+
+      ##
+      # Returns gradient buffers on all contexts, in the same order as
+      # creation.
+      #
+      # ====Returns
+      #
+      # List of NDArrays.
+      #
+      def list_grad
+        if !@grad && @data
+          raise RuntimeError,
+                "Cannot get gradient buffers for Parameter '#{name}' " \
+                "because grad_req=:null."
+        end
+        check_and_get(@grad, :all)
+      end
+
+      ##
+      # Sets gradient buffer to zero on all contexts.
+      #
+      def zero_grad
+        if @grad
+          check_and_get(@grad, :all).each do |arr|
+            arr[0..-1] = 0
+          end
+        else
+          if @deferred_init.empty?
+            raise RuntimeError, "Parameter '#{@name}' has not been initialized."
+          end
+        end
+      end
+
+      def to_s
+        "Parameter #{@name} (shape=#{@shape.inspect}, dtype=#{MXNet::DType.id2name(@dtype)})"
+      end
+
+      def ==(other)
+        self.name == other.name && self.shape == other.shape
+      rescue NoMethodError
+        false
+      end
+
+      private
+
+      ##
+      # Reduce data from multiple contexts to cpu.
+      #
+      def reduce
+        data = list_data.map { |d| d.copy_to(MXNet.cpu) }
+        MXNet::NDArray.add_n(*data) / data.length
+      end
+
+      def check_and_get(arr_list, ctx)
+        unless arr_list.nil?
+          if ctx == :all
+            return arr_list
+          elsif ctx.nil?
+            if arr_list.length == 1
+              return arr_list[0]
+            end
+            ctx = MXNet.current_context
+          end
+          if data = arr_list.find { |arr| arr.context == ctx }
+            return data
+          end
+          raise RuntimeError,
+                "Parameter '#{@name}' was not initialized on context #{ctx}."
+        end
+        unless @deferred_init.empty?
+          raise DeferredInitializationError,
+                "Parameter '#{@name}' has not been initialized yet because " \
+                "initialization was deferred. Actual initialization happens " \
+                "during the first forward pass. Please pass one batch of " \
+                "data through the network before accessing Parameters."
+        end
+        raise RuntimeError,
+              "Parameter '#{@name}' has not been initialized. You should " \
+              "initialize parameters and create a Trainer with #collect_params " \
+              "instead of #params because the later does not include Parameters " \
+              "of nested child Blocks."
+      end
+
+      def load_and_init(ctx, data)
+        ctx = ctx.is_a?(MXNet::Context) ? [ctx] : ctx
+        if @data
+          set_data(data)
+        else
+          init_impl(ctx, data)
+        end
+      end
+
+      def finish_deferred_init
+        return if @deferred_init.empty?
+        ctx, default_init, data = @deferred_init
+        @deferred_init = []
+        if @shape.nil? || @shape.flatten.inject(&:*) <= 0
           raise RuntimeError,
                 "Cannot initialize Parameter '#{@name}' because it has " \
                 "invalid shape: #{@shape}."
         end
-        @deferred_init = [ctx, init, nil]
-        return
-      end
-      @deferred_init = [ctx, init, nil]
-      finish_deferred_init
-    end
-
-    ##
-    # Returns a list of contexts this parameter is initialized on.
-    #
-    def list_ctx
-      if @data.nil?
-        unless @deferred_init.empty?
-          @deferred_init[0]
-        else
-          raise RuntimeError, "Parameter '#{@name}' has not been initialized."
-        end
-      else
-        @ctx
-      end
-    end
-
-    ##
-    # Returns a symbol representing this parameter.
-    #
-    def var
-      @var ||= MXNet::Symbol.var(@name, shape: @shape, dtype: @dtype)
-    end
-
-    ##
-    # Returns a copy of this parameter on one context. Must have been
-    # initialized on this context before.
-    #
-    # ====Parameters
-    #
-    # +ctx+:: (Context)
-    #         Desired context.
-    #
-    # ====Returns
-    #
-    # NDArray on context.
-    #
-    def data(ctx: nil)
-      check_and_get(@data, ctx)
-    end
-
-    ##
-    # Returns copies of this parameter on all contexts, in the same
-    # order as creation.
-    #
-    # ====Returns
-    #
-    # List of NDArrays.
-    #
-    def list_data
-      check_and_get(@data, :all)
-    end
-
-    ##
-    # Sets this parameter's value on all contexts.
-    #
-    def set_data(data)
-      @shape = data.shape
-      if @data
-        check_and_get(@data, :all).each do |arr|
-          arr[0..-1] = data
-        end
-      else
-        unless @deferred_init.empty?
-          @deferred_init[2] = data
-        else
-          raise RuntimeError, "Parameter '#{@name}' has not been initialized."
-        end
-      end
-    end
-
-    ##
-    # Returns a gradient buffer for this parameter on one context.
-    # Must have been initialized on this context before.
-    #
-    # ====Parameters
-    #
-    # +ctx+:: (Context) Desired context.
-    #
-    # ====Returns
-    #
-    # NDArray on context.
-    #
-    def grad(ctx: nil)
-      if !@grad && @data
-        raise RuntimeError,
-              "Cannot get gradient buffer for Parameter '#{name}' " \
-              "because grad_req=:null."
-      end
-      check_and_get(@grad, ctx)
-    end
-
-    ##
-    # Returns gradient buffers on all contexts, in the same order as
-    # creation.
-    #
-    # ====Returns
-    #
-    # List of NDArrays.
-    #
-    def list_grad
-      if !@grad && @data
-        raise RuntimeError,
-              "Cannot get gradient buffers for Parameter '#{name}' " \
-              "because grad_req=:null."
-      end
-      check_and_get(@grad, :all)
-    end
-
-    ##
-    # Sets gradient buffer to zero on all contexts.
-    #
-    def zero_grad
-      if @grad
-        check_and_get(@grad, :all).each do |arr|
-          arr[0..-1] = 0
-        end
-      else
-        if @deferred_init.empty?
-          raise RuntimeError, "Parameter '#{@name}' has not been initialized."
-        end
-      end
-    end
-
-    def to_s
-      "Parameter #{@name} (shape=#{@shape.inspect}, dtype=#{MXNet::DType.id2name(@dtype)})"
-    end
-
-    def ==(other)
-      self.name == other.name && self.shape == other.shape
-    rescue NoMethodError
-      false
-    end
-
-    private
-
-    ##
-    # Reduce data from multiple contexts to cpu.
-    #
-    def reduce
-      data = list_data.map { |d| d.copy_to(MXNet.cpu) }
-      MXNet::NDArray.add_n(*data) / data.length
-    end
-
-    def check_and_get(arr_list, ctx)
-      unless arr_list.nil?
-        if ctx == :all
-          return arr_list
-        elsif ctx.nil?
-          if arr_list.length == 1
-            return arr_list[0]
+        MXNet::Autograd.pause do
+          unless data
+            data = MXNet::NDArray.zeros(@shape, dtype: @dtype, ctx: MXNet.cpu)
+            MXNet::Initializer.create(default_init)[data]
           end
-          ctx = MXNet.current_context
-        end
-        if data = arr_list.find { |arr| arr.context == ctx }
-          return data
-        end
-        raise RuntimeError,
-              "Parameter '#{@name}' was not initialized on context #{ctx}."
-      end
-      unless @deferred_init.empty?
-        raise DeferredInitializationError,
-              "Parameter '#{@name}' has not been initialized yet because " \
-              "initialization was deferred. Actual initialization happens " \
-              "during the first forward pass. Please pass one batch of " \
-              "data through the network before accessing Parameters."
-      end
-      raise RuntimeError,
-            "Parameter '#{@name}' has not been initialized. You should " \
-            "initialize parameters and create a Trainer with #collect_params " \
-            "instead of #params because the later does not include Parameters " \
-            "of nested child Blocks."
-    end
-
-    def load_and_init(ctx, data)
-      ctx = ctx.is_a?(MXNet::Context) ? [ctx] : ctx
-      if @data
-        set_data(data)
-      else
-        init_impl(ctx, data)
-      end
-    end
-
-    def finish_deferred_init
-      return if @deferred_init.empty?
-      ctx, default_init, data = @deferred_init
-      @deferred_init = []
-      if @shape.nil? || @shape.flatten.inject(&:*) <= 0
-        raise RuntimeError,
-              "Cannot initialize Parameter '#{@name}' because it has " \
-              "invalid shape: #{@shape}."
-      end
-      MXNet::Autograd.pause do
-        unless data
-          data = MXNet::NDArray.zeros(@shape, dtype: @dtype, ctx: MXNet.cpu)
-          MXNet::Initializer.create(default_init)[data]
-        end
-        init_impl(ctx, data)
-      end
-    end
-
-    def init_impl(ctx, data)
-      @data = ctx.map { |c| data.copy_to(c) }
-      grad = MXNet::NDArray.zeros(@shape, dtype: @dtype, ctx: MXNet.cpu)
-      init_grad(ctx, grad)
-    end
-
-    def init_grad(ctx, grad)
-      if @grad_req == :null
-        @grad = nil
-        return
-      end
-      @grad = ctx.map { |c| grad.copy_to(c) }
-      MXNet::Autograd.mark_variables(
-        check_and_get(@data, :all),
-        check_and_get(@grad, :all),
-        grad_reqs: @grad_req
-      )
-    end
-  end
-
-  ##
-  # A dictionary managing a set of Parameters.
-  #
-  class ParameterDict
-    include Enumerable
-
-    ##
-    # Creates a new instance.
-    #
-    # ====Parameters
-    #
-    # +prefix+:: (string, default "")
-    #            The prefix to be prepended to all Parameters' names
-    #            created by this dict.
-    # +shared+:: (ParameterDict or +nil+)
-    #            If not +nil+, when this dict's #get method creates a
-    #            new parameter, will first try to retrieve it from
-    #            "shared" dict. Usually used for sharing parameters
-    #            with another Block.
-    #
-    def initialize(prefix: '', shared: nil)
-      @params = {}
-      @prefix = prefix
-      @shared = shared
-    end
-
-    def each(&block)
-      @params.each(&block)
-    end
-
-    def keys
-      @params.keys
-    end
-
-    def values
-      @params.values
-    end
-
-    ##
-    # Prefix of this dict. It will be prepended to a Parameter's name
-    # created with #get.
-    #
-    def prefix
-      @prefix
-    end
-
-    ##
-    # Retrieves a Parameter with name "<prefix><name>". If not found,
-    # #get will first try to retrieve it from "shared" dict. If still
-    # not found, #get will create a new Parameter with key-word
-    # arguments and both store and return it.
-    #
-    # ====Parameters
-    #
-    # +name+:: (string)
-    #          Name of the desired Parameter. It will be prepended
-    #          with this dict's prefix.
-    #
-    # ====Returns
-    #
-    # The created or retrieved Parameter.
-    #
-    def get(name, **kwargs)
-      name = @prefix + name
-      unless param = _get(name.to_sym)
-        param = @params[name.to_sym] = Parameter.new(name, **kwargs)
-      else
-        param
-      end
-    end
-
-    ##
-    # Copies all Parameters in +other+ to this dict.
-    #
-    def update(other)
-      other.each do |k, v|
-        if @params[k] && @params[k] != v
-          raise ArgumentError, "Cannot update because keys have different values: #{@params[k]}, #{v}"
+          init_impl(ctx, data)
         end
       end
-      other.each do |k, v|
-        @params[k] = v
+
+      def init_impl(ctx, data)
+        @data = ctx.map { |c| data.copy_to(c) }
+        grad = MXNet::NDArray.zeros(@shape, dtype: @dtype, ctx: MXNet.cpu)
+        init_grad(ctx, grad)
+      end
+
+      def init_grad(ctx, grad)
+        if @grad_req == :null
+          @grad = nil
+          return
+        end
+        @grad = ctx.map { |c| grad.copy_to(c) }
+        MXNet::Autograd.mark_variables(
+          check_and_get(@data, :all),
+          check_and_get(@grad, :all),
+          grad_reqs: @grad_req
+        )
       end
     end
 
     ##
-    # Initializes all Parameters managed by this dict to be used for
-    # NDArray API. It has no effect when using Symbol API.
+    # A dictionary managing a set of Parameters.
     #
-    # ====Parameters
-    #
-    # +init+::         (Initializer, default +nil+)
-    #                  The initializer to use.
-    # +ctx+::          (Context or array of Context)
-    #                  Desired contexts. Initialize Parameter on given
-    #                  contexts.
-    # +force_reinit+:: (boolean, default false)
-    #                  Whether to force re-initialization if parameters
-    #                  are already initialized.
-    #
-    def init(init: nil, ctx: nil, force_reinit: false)
-      values.each { |v| v.init(init: init, ctx: ctx, force_reinit: force_reinit) }
-    end
+    class ParameterDict
+      include Enumerable
 
-    def to_s
-      "ParameterDict (\n" +
-        self.inject('') { |a, (n, p)| a + "  #{p}\n" } +
-        ')'
-    end
+      ##
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +prefix+:: (string, default "")
+      #            The prefix to be prepended to all Parameters' names
+      #            created by this dict.
+      # +shared+:: (ParameterDict or +nil+)
+      #            If not +nil+, when this dict's #get method creates a
+      #            new parameter, will first try to retrieve it from
+      #            "shared" dict. Usually used for sharing parameters
+      #            with another Block.
+      #
+      def initialize(prefix: '', shared: nil)
+        @params = {}
+        @prefix = prefix
+        @shared = shared
+      end
 
-    def ==(other)
-      self.prefix == other.prefix && self.each.to_a == other.each.to_a
-    rescue NoMethodError
-      false
-    end
+      def each(&block)
+        @params.each(&block)
+      end
 
-    protected
+      def keys
+        @params.keys
+      end
 
-    def _get(name)
-      if value = @params[name]
-        value
-      elsif @shared && value = @shared._get(name)
-        @params[name] = value
-        value
+      def values
+        @params.values
+      end
+
+      ##
+      # Prefix of this dict. It will be prepended to a Parameter's name
+      # created with #get.
+      #
+      def prefix
+        @prefix
+      end
+
+      ##
+      # Retrieves a Parameter with name "<prefix><name>". If not found,
+      # #get will first try to retrieve it from "shared" dict. If still
+      # not found, #get will create a new Parameter with key-word
+      # arguments and both store and return it.
+      #
+      # ====Parameters
+      #
+      # +name+:: (string)
+      #          Name of the desired Parameter. It will be prepended
+      #          with this dict's prefix.
+      #
+      # ====Returns
+      #
+      # The created or retrieved Parameter.
+      #
+      def get(name, **kwargs)
+        name = @prefix + name
+        unless param = _get(name.to_sym)
+          param = @params[name.to_sym] = Parameter.new(name, **kwargs)
+        else
+          param
+        end
+      end
+
+      ##
+      # Copies all Parameters in +other+ to this dict.
+      #
+      def update(other)
+        other.each do |k, v|
+          if @params[k] && @params[k] != v
+            raise ArgumentError, "Cannot update because keys have different values: #{@params[k]}, #{v}"
+          end
+        end
+        other.each do |k, v|
+          @params[k] = v
+        end
+      end
+
+      ##
+      # Initializes all Parameters managed by this dict to be used for
+      # NDArray API. It has no effect when using Symbol API.
+      #
+      # ====Parameters
+      #
+      # +init+::         (Initializer, default +nil+)
+      #                  The initializer to use.
+      # +ctx+::          (Context or array of Context)
+      #                  Desired contexts. Initialize Parameter on given
+      #                  contexts.
+      # +force_reinit+:: (boolean, default false)
+      #                  Whether to force re-initialization if parameters
+      #                  are already initialized.
+      #
+      def init(init: nil, ctx: nil, force_reinit: false)
+        values.each { |v| v.init(init: init, ctx: ctx, force_reinit: force_reinit) }
+      end
+
+      def to_s
+        "ParameterDict (\n" +
+          self.inject('') { |a, (n, p)| a + "  #{p}\n" } +
+          ')'
+      end
+
+      def ==(other)
+        self.prefix == other.prefix && self.each.to_a == other.each.to_a
+      rescue NoMethodError
+        false
+      end
+
+      protected
+
+      def _get(name)
+        if value = @params[name]
+          value
+        elsif @shared && value = @shared._get(name)
+          @params[name] = value
+          value
+        end
       end
     end
   end

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -1,0 +1,187 @@
+require 'mxnet/gluon'
+
+module MXNet::Gluon
+  ##
+  # A Container holding parameters (weights) of Blocks.
+  #
+  # ====Parameters
+  #
+  # +name+::  (string) Name of this parameter.
+  # +shape+:: (integer or array of integers) Shape of this parameter.
+  #           By default shape is not specified.
+  #
+  class Parameter
+    def initialize(name, shape: nil, dtype: 0)
+      @name = name
+      shape = [shape] if shape.is_a?(Integer)
+      self.shape = shape
+      @dtype = dtype
+      @data = nil
+      @grad = nil
+    end
+    def name
+      @name
+    end
+    def shape
+      @shape
+    end
+    def shape=(shape)
+      @shape ||= shape
+    end
+    ##
+    # Initializes parameter and gradient arrays. Only used for NDArray
+    # API.
+    #
+    # ====Parameters
+    #
+    # +ctx+::          (Context or array of Contexts)
+    #                  Desired contexts. Initialize Parameter on
+    #                  given contexts.
+    # +default_init+:: (Initializer, default MXNet::Uniform)
+    #                  Default initializer.
+    #
+    def init(ctx: nil, default_init: MXNet::Uniform)
+      @data = @grad = nil
+      ctx = [MXNet.current_context] if ctx.nil?
+      ctx = [ctx] if ctx.is_a?(MXNet::Context)
+      data = MXNet::NDArray.zeros(@shape, dtype: @dtype, ctx: MXNet.cpu)
+      default_init.new[data]
+      @data = ctx.map { |c| data.copy_to(c) }
+    end
+    ##
+    # Returns a copy of this parameter on one context. Must have been
+    # initialized on this context before.
+    #
+    # ====Parameters
+    #
+    # +ctx+:: (Context) Desired context.
+    #
+    # ====Returns
+    #
+    # NDArray on context.
+    #
+    def data(ctx: nil)
+      check_and_get(@data, ctx)
+    end
+    def to_s
+      "Parameter #{@name} (shape=#{@shape.inspect}, dtype=#{@dtype.inspect})"
+    end
+    def ==(other)
+      self.name == other.name && self.shape == other.shape
+    rescue NoMethodError
+      false
+    end
+    private
+    def check_and_get(arr_list, ctx)
+      unless arr_list.nil?
+        if ctx.nil?
+          if arr_list.length == 1
+            return arr_list[0]
+          end
+          ctx = MXNet.current_context
+        end
+        if data = arr_list.find { |arr| arr.context == ctx }
+          return data
+        end
+        raise RuntimeError.new("Parameter '#{self.name}' was not initialized on context #{ctx}.")
+      end
+      raise RuntimeError.new("Parameter '#{self.name}' has not been initialized. You should initialize parameters.")
+    end
+  end
+  ##
+  # A dictionary managing a set of Parameters.
+  #
+  # ====Parameters
+  #
+  # +prefix+:: (string, default "") The prefix to be prepended to all
+  #            Parameters' names created by this dict.
+  # +shared+:: (ParameterDict or +nil+) If not +nil+, when this dict's
+  #            #get method creates a new parameter, will first try to
+  #            retrieve it from "shared" dict. Usually used for
+  #            sharing parameters with another Block.
+  #
+  class ParameterDict
+    include Enumerable
+    def initialize(prefix: '', shared: nil)
+      @params = {}
+      @prefix = prefix
+      @shared = shared
+    end
+    def each(&block)
+      @params.each(&block)
+    end
+    ##
+    # Prefix of this dict. It will be prepended to a Parameter's name
+    # created with #get.
+    #
+    def prefix
+      @prefix
+    end
+    ##
+    # Retrieves a Parameter with name "<prefix><name>". If not found,
+    # #get will first try to retrieve it from "shared" dict. If still
+    # not found, #get will create a new Parameter with key-word
+    # arguments and both store and return it.
+    #
+    # ====Parameters
+    #
+    # +name+:: (string) Name of the desired Parameter. It will be
+    #          prepended with this dict's prefix.
+    #
+    # ====Returns
+    #
+    # The created or retrieved Parameter.
+    #
+    def get(name, **kwargs)
+      name = @prefix + name
+      unless param = _get(name)
+        param = @params[name] = Parameter.new(name, **kwargs)
+      else
+        param
+      end
+    end
+    ##
+    # Copies all Parameters in +other+ to this dict.
+    #
+    def update(other)
+      other.each do |k, v|
+        if @params[k] && @params[k] != v
+          raise ArgumentError, "Cannot update because keys have different values: #{@params[k]}, #{v}"
+        end
+      end
+      other.each do |k, v|
+        @params[k] = v
+      end
+    end
+    ##
+    # Initializes all Parameters managed by this dict to be used for
+    # NDArray API. It has no effect when using Symbol API.
+    #
+    # +ctx+:: (Context or array of Context)
+    #         Desired contexts. Initialize Parameter on
+    #         given contexts.
+    #
+    def init(ctx: nil)
+      self.each { |_, v| v.init(ctx: ctx) }
+    end
+    def to_s
+      "ParameterDict (\n" +
+        self.inject('') { |a, (n, p)| a + "  #{p}\n" } +
+        ')'
+    end
+    def ==(other)
+      self.prefix == other.prefix && self.each.to_a == other.each.to_a
+    rescue NoMethodError
+      false
+    end
+    protected
+    def _get(name)
+      if value = @params[name]
+        value
+      elsif @shared && value = @shared._get(name)
+        @params[name] = value
+        value
+      end
+    end
+  end
+end

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -20,6 +20,7 @@ module MXNet::Gluon
   #
   class Parameter
     def initialize(name, shape: nil, dtype: 0, allow_deferred_init: false)
+      @var = nil
       @name = name
       shape = [shape] if shape.is_a?(Integer)
       @shape = shape
@@ -107,6 +108,12 @@ module MXNet::Gluon
       else
         @ctx
       end
+    end
+    ##
+    # Returns a symbol representing this parameter.
+    #
+    def var
+      @var ||= MXNet::Symbol.var(@name, shape: @shape, dtype: @dtype)
     end
     ##
     # Returns a copy of this parameter on one context. Must have been

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -19,12 +19,12 @@ module MXNet::Gluon
   #           By default shape is not specified.
   #
   class Parameter
-    def initialize(name, shape: nil, dtype: 0, allow_deferred_init: false)
+    def initialize(name, shape: nil, dtype: :float32, allow_deferred_init: false)
       @var = nil
       @name = name
       shape = [shape] if shape.is_a?(Integer)
-      @shape = shape
-      @dtype = dtype
+      self.shape = shape
+      self.dtype = dtype
       @data = nil
       @grad = nil
       @deferred_init = []
@@ -49,6 +49,14 @@ module MXNet::Gluon
         end
         @shape = shape
       end
+    end
+    def dtype
+      @dtype
+    end
+    def dtype=(dtype)
+      @dtype = dtype.is_a?(::String) || dtype.is_a?(::Symbol) ?
+                 MXNet::DType.name2id(dtype) :
+                 dtype
     end
     def trainer
       @trainer
@@ -168,7 +176,7 @@ module MXNet::Gluon
       check_and_get(@grad, :all)
     end
     def to_s
-      "Parameter #{@name} (shape=#{@shape.inspect}, dtype=#{@dtype.inspect})"
+      "Parameter #{@name} (shape=#{@shape.inspect}, dtype=#{MXNet::DType.id2name(@dtype)})"
     end
     def ==(other)
       self.name == other.name && self.shape == other.shape

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -83,6 +83,13 @@ module MXNet::Gluon
     #                  Whether to force re-initialization if parameter
     #                  is already initialized.
     #
+    # ====Examples
+    #
+    #     weight = MXNet::Gluon::Parameter.new('weight', shape: [2, 2])
+    #     weight.init(ctx: MXNet.cpu)
+    #     weight.data # => [[0.0068339, 0.0129982],...
+    #     weight.grad # => [[0, 0],...
+    #
     def init(ctx: nil, default_init: :uniform, force_reinit: false)
       unless @data.nil? || force_reinit
         return

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -399,8 +399,8 @@ module MXNet::Gluon
     #
     def get(name, **kwargs)
       name = @prefix + name
-      unless param = _get(name)
-        param = @params[name] = Parameter.new(name, **kwargs)
+      unless param = _get(name.to_sym)
+        param = @params[name.to_sym] = Parameter.new(name, **kwargs)
       else
         param
       end

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -58,13 +58,9 @@ module MXNet
         @trainer = nil
       end
 
-      def name
-        @name
-      end
+      attr_reader :name
 
-      def shape
-        @shape
-      end
+      attr_reader :shape
 
       def shape=(shape)
         if @shape.nil?
@@ -80,9 +76,7 @@ module MXNet
         end
       end
 
-      def dtype
-        @dtype
-      end
+      attr_reader :dtype
 
       def dtype=(dtype)
         @dtype = dtype.is_a?(::String) || dtype.is_a?(::Symbol) ?
@@ -90,13 +84,7 @@ module MXNet
                    dtype
       end
 
-      def trainer
-        @trainer
-      end
-
-      def trainer=(trainer)
-        @trainer = trainer
-      end
+      attr_accessor :trainer
 
       ##
       # Initializes parameter and gradient arrays. Only used for NDArray
@@ -343,7 +331,7 @@ module MXNet
         MXNet::Autograd.pause do
           unless data
             data = MXNet::NDArray.zeros(@shape, dtype: @dtype, ctx: MXNet.cpu)
-            MXNet::Initializer.create(default_init)[data]
+            MXNet::Initializer.create(default_init).init_array(data)
           end
           init_impl(ctx, data)
         end
@@ -403,8 +391,16 @@ module MXNet
         @params.keys
       end
 
+      def key?(key)
+        @params.key?(key)
+      end
+
       def values
         @params.values
+      end
+
+      def value?(value)
+        @params.value?(value)
       end
 
       ##
@@ -435,9 +431,8 @@ module MXNet
         name = @prefix + name
         unless param = _get(name.to_sym)
           param = @params[name.to_sym] = Parameter.new(name, **kwargs)
-        else
-          param
         end
+        param
       end
 
       ##

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -70,7 +70,9 @@ module MXNet::Gluon
     #
     # ====Parameters
     #
-    # +ctx+::          (Context or array of Contexts)
+    # +init+::         (Initializer, default +nil+)
+    #                  The initializer to use. Overrides `default_init`.
+    # +ctx+::          (Context or array of Contexts, default +nil+)
     #                  Desired contexts. Initialize Parameter on given
     #                  contexts. A copy will be made for each
     #                  context. Note: copies are independent
@@ -90,10 +92,11 @@ module MXNet::Gluon
     #     weight.data # => [[0.0068339, 0.0129982],...
     #     weight.grad # => [[0, 0],...
     #
-    def init(ctx: nil, default_init: :uniform, force_reinit: false)
+    def init(init: nil, ctx: nil, default_init: :uniform, force_reinit: false)
       unless @data.nil? || force_reinit
         return
       end
+      init = default_init if init.nil?
       ctx = [MXNet.current_context] if ctx.nil?
       ctx = [ctx] if ctx.is_a?(MXNet::Context)
       @ctx = ctx
@@ -104,10 +107,10 @@ module MXNet::Gluon
                 "Cannot initialize Parameter '#{@name}' because it has " \
                 "invalid shape: #{@shape}."
         end
-        @deferred_init = [ctx, default_init]
+        @deferred_init = [ctx, init]
         return
       end
-      @deferred_init = [ctx, default_init]
+      @deferred_init = [ctx, init]
       finish_deferred_init
     end
     ##
@@ -317,6 +320,8 @@ module MXNet::Gluon
     # Initializes all Parameters managed by this dict to be used for
     # NDArray API. It has no effect when using Symbol API.
     #
+    # +init+::         (Initializer, default +nil+)
+    #                  The initializer to use.
     # +ctx+::          (Context or array of Context)
     #                  Desired contexts. Initialize Parameter on given
     #                  contexts.
@@ -324,8 +329,8 @@ module MXNet::Gluon
     #                  Whether to force re-initialization if parameters
     #                  are already initialized.
     #
-    def init(ctx: nil, force_reinit: false)
-      self.each { |_, v| v.init(ctx: ctx, force_reinit: force_reinit) }
+    def init(init: nil, ctx: nil, force_reinit: false)
+      values.each { |v| v.init(init: init, ctx: ctx, force_reinit: force_reinit) }
     end
     def to_s
       "ParameterDict (\n" +

--- a/lib/mxnet/gluon/parameter.rb
+++ b/lib/mxnet/gluon/parameter.rb
@@ -25,13 +25,17 @@ module MXNet::Gluon
     #           specified.
     # +dtype+:: (symbol or string, default +:float32+)
     #           Data type of this parameter.
+    # +init+::  (Initializer, default +nil+)
+    #           The initializer to use.
     #
-    def initialize(name, shape: nil, dtype: :float32)
+    def initialize(name, shape: nil, dtype: :float32, init: nil,
+                   allow_deferred_init: false)
       @var = nil
       @name = name
       shape = [shape] if shape.is_a?(Integer)
       self.shape = shape
       self.dtype = dtype
+      @init = init
       @data = nil
       @grad = nil
       @deferred_init = []
@@ -78,7 +82,9 @@ module MXNet::Gluon
     # ====Parameters
     #
     # +init+::         (Initializer, default +nil+)
-    #                  The initializer to use. Overrides `default_init`.
+    #                  The initializer to use. Overrides both `init`,
+    #                  set when this instance was created, and
+    #                  `default_init` in this call.
     # +ctx+::          (Context or array of Contexts, default +nil+)
     #                  Desired contexts. Initialize Parameter on given
     #                  contexts. A copy will be made for each
@@ -103,7 +109,7 @@ module MXNet::Gluon
       unless @data.nil? || force_reinit
         return
       end
-      init = default_init if init.nil?
+      init = (@init || default_init) if init.nil?
       ctx = [MXNet.current_context] if ctx.nil?
       ctx = [ctx] if ctx.is_a?(MXNet::Context)
       @ctx = ctx

--- a/lib/mxnet/gluon/trainer.rb
+++ b/lib/mxnet/gluon/trainer.rb
@@ -1,4 +1,5 @@
 require 'mxnet/gluon'
+require 'mxnet/optimizer'
 
 module MXNet::Gluon
   ##
@@ -82,12 +83,7 @@ module MXNet::Gluon
       @contexts = contexts
     end
     def init_optimizer(optimizer, optimizer_params)
-      @optimizer =
-        unless optimizer.is_a?(MXNet::Optimizer)
-          optimizer.new(**optimizer_params)
-        else
-          optimizer
-        end
+      @optimizer = MXNet::Optimizer.create(optimizer, **optimizer_params)
     end
     def _update
       @params.each.with_index do |param, i|

--- a/lib/mxnet/gluon/trainer.rb
+++ b/lib/mxnet/gluon/trainer.rb
@@ -1,0 +1,100 @@
+require 'mxnet/gluon'
+
+module MXNet::Gluon
+  ##
+  # Applies an Optimizer on a set of Parameters. Trainer should be
+  # used together with +autograd+.
+  #
+  class Trainer
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +params+::           (ParameterDict)
+    #                      The set of parameters to optimize.
+    # +optimizer+::        (Optimizer)
+    #                      The optimizer to use.
+    # +optimizer_params+:: (Hash)
+    #                      Key-word arguments to be passed to
+    #                      optimizer constructor. For example,
+    #                      <tt>{'learning_rate': 0.1}</tt>. See each
+    #                      optimizer's constructor for a list of
+    #                      additional supported arguments.
+    #
+    def initialize(params, optimizer, optimizer_params = {})
+      if params.is_a?(Hash) || params.is_a?(ParameterDict)
+        params = params.values
+      end
+      @params = []
+      params.each.with_index do |param, i|
+        unless param.is_a?(Parameter)
+          raise ArgumentError, 'First argument must be a Hash or ParameterDict.'
+        end
+        param.trainer = self
+        @params << param
+      end
+      check_contexts
+      init_optimizer(optimizer, optimizer_params)
+      @scale = optimizer_params[:rescale_grad] || 1.0
+    end
+    ##
+    # Makes one step of parameter update.
+    #
+    # ====Parameters
+    #
+    # +batch_size+:: (integer)
+    #                Batch size of data processed. Gradient will be
+    #                normalized by `1/batch_size`. Set this to 1 if
+    #                you normalized loss manually with `loss =
+    #                mean(loss)`.
+    #
+    def step(batch_size)
+      @optimizer.rescale_grad = @scale / batch_size
+      _update
+    end
+    ##
+    # Makes one step of parameter update.
+    #
+    # ====Parameter
+    #
+    # +batch_size+:: (integer)
+    #                Batch size of data processed. Gradient will be
+    #                normalized by `1/batch_size`. Set this to 1 if
+    #                you normalized loss manually with `loss =
+    #                mean(loss)`.
+    #
+    def update(batch_size)
+      @optimizer.rescale_grad = @scale / batch_size
+      _update
+    end
+    private
+    def check_contexts
+      contexts = nil
+      @params.each do |param|
+        unless contexts.nil? || contexts == param.list_ctx
+          raise RuntimeError,
+                "All Parameters must be initialized on the same set of contexts, " \
+                "but Parameter '#{param.name}' is initialized on '#{param.list_ctx.map(&:to_s)}' " \
+                "while previous Parameters are initialized on '#{contexts.map(&:to_s)}'."
+        end
+        contexts = param.list_ctx
+      end
+      @contexts = contexts
+    end
+    def init_optimizer(optimizer, optimizer_params)
+      @optimizer =
+        unless optimizer.is_a?(MXNet::Optimizer)
+          optimizer.new(**optimizer_params)
+        else
+          optimizer
+        end
+    end
+    def _update
+      @params.each.with_index do |param, i|
+        param.list_data.zip(param.list_grad) do |data, grad|
+          @optimizer.update(i, data, grad, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/mxnet/gluon/trainer.rb
+++ b/lib/mxnet/gluon/trainer.rb
@@ -38,6 +38,7 @@ module MXNet::Gluon
       init_optimizer(optimizer, optimizer_params)
       @scale = optimizer_params[:rescale_grad] || 1.0
     end
+
     ##
     # Makes one step of parameter update.
     #
@@ -53,6 +54,7 @@ module MXNet::Gluon
       @optimizer.rescale_grad = @scale / batch_size
       _update
     end
+
     ##
     # Makes one step of parameter update.
     #
@@ -68,7 +70,9 @@ module MXNet::Gluon
       @optimizer.rescale_grad = @scale / batch_size
       _update
     end
+
     private
+
     def check_contexts
       contexts = nil
       @params.each do |param|
@@ -82,9 +86,11 @@ module MXNet::Gluon
       end
       @contexts = contexts
     end
+
     def init_optimizer(optimizer, optimizer_params)
       @optimizer = MXNet::Optimizer.create(optimizer, **optimizer_params)
     end
+
     def _update
       @params.each.with_index do |param, i|
         param.list_data.zip(param.list_grad) do |data, grad|

--- a/lib/mxnet/gluon/trainer.rb
+++ b/lib/mxnet/gluon/trainer.rb
@@ -100,5 +100,9 @@ module MXNet
         end
       end
     end
+
+    def self.Trainer(*args)
+      Trainer.new(*args)
+    end
   end
 end

--- a/lib/mxnet/gluon/trainer.rb
+++ b/lib/mxnet/gluon/trainer.rb
@@ -1,100 +1,102 @@
 require 'mxnet/gluon'
 require 'mxnet/optimizer'
 
-module MXNet::Gluon
-  ##
-  # Applies an Optimizer on a set of Parameters. Trainer should be
-  # used together with +autograd+.
-  #
-  class Trainer
-    # Creates a new instance.
-    #
-    # ====Parameters
-    #
-    # +params+::           (ParameterDict)
-    #                      The set of parameters to optimize.
-    # +optimizer+::        (Optimizer)
-    #                      The optimizer to use.
-    # +optimizer_params+:: (Hash)
-    #                      Key-word arguments to be passed to
-    #                      optimizer constructor. For example,
-    #                      <tt>{'learning_rate': 0.1}</tt>. See each
-    #                      optimizer's constructor for a list of
-    #                      additional supported arguments.
-    #
-    def initialize(params, optimizer, optimizer_params = {})
-      if params.is_a?(Hash) || params.is_a?(ParameterDict)
-        params = params.values
-      end
-      @params = []
-      params.each.with_index do |param, i|
-        unless param.is_a?(Parameter)
-          raise ArgumentError, 'First argument must be a Hash or ParameterDict.'
-        end
-        param.trainer = self
-        @params << param
-      end
-      check_contexts
-      init_optimizer(optimizer, optimizer_params)
-      @scale = optimizer_params[:rescale_grad] || 1.0
-    end
-
+module MXNet
+  module Gluon
     ##
-    # Makes one step of parameter update.
+    # Applies an Optimizer on a set of Parameters. Trainer should be
+    # used together with +autograd+.
     #
-    # ====Parameters
-    #
-    # +batch_size+:: (integer)
-    #                Batch size of data processed. Gradient will be
-    #                normalized by `1/batch_size`. Set this to 1 if
-    #                you normalized loss manually with `loss =
-    #                mean(loss)`.
-    #
-    def step(batch_size)
-      @optimizer.rescale_grad = @scale / batch_size
-      _update
-    end
-
-    ##
-    # Makes one step of parameter update.
-    #
-    # ====Parameter
-    #
-    # +batch_size+:: (integer)
-    #                Batch size of data processed. Gradient will be
-    #                normalized by `1/batch_size`. Set this to 1 if
-    #                you normalized loss manually with `loss =
-    #                mean(loss)`.
-    #
-    def update(batch_size)
-      @optimizer.rescale_grad = @scale / batch_size
-      _update
-    end
-
-    private
-
-    def check_contexts
-      contexts = nil
-      @params.each do |param|
-        unless contexts.nil? || contexts == param.list_ctx
-          raise RuntimeError,
-                "All Parameters must be initialized on the same set of contexts, " \
-                "but Parameter '#{param.name}' is initialized on '#{param.list_ctx.map(&:to_s)}' " \
-                "while previous Parameters are initialized on '#{contexts.map(&:to_s)}'."
+    class Trainer
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +params+::           (ParameterDict)
+      #                      The set of parameters to optimize.
+      # +optimizer+::        (Optimizer)
+      #                      The optimizer to use.
+      # +optimizer_params+:: (Hash)
+      #                      Key-word arguments to be passed to
+      #                      optimizer constructor. For example,
+      #                      <tt>{'learning_rate': 0.1}</tt>. See each
+      #                      optimizer's constructor for a list of
+      #                      additional supported arguments.
+      #
+      def initialize(params, optimizer, optimizer_params = {})
+        if params.is_a?(Hash) || params.is_a?(ParameterDict)
+          params = params.values
         end
-        contexts = param.list_ctx
+        @params = []
+        params.each.with_index do |param, i|
+          unless param.is_a?(Parameter)
+            raise ArgumentError, 'First argument must be a Hash or ParameterDict.'
+          end
+          param.trainer = self
+          @params << param
+        end
+        check_contexts
+        init_optimizer(optimizer, optimizer_params)
+        @scale = optimizer_params[:rescale_grad] || 1.0
       end
-      @contexts = contexts
-    end
 
-    def init_optimizer(optimizer, optimizer_params)
-      @optimizer = MXNet::Optimizer.create(optimizer, **optimizer_params)
-    end
+      ##
+      # Makes one step of parameter update.
+      #
+      # ====Parameters
+      #
+      # +batch_size+:: (integer)
+      #                Batch size of data processed. Gradient will be
+      #                normalized by `1/batch_size`. Set this to 1 if
+      #                you normalized loss manually with `loss =
+      #                mean(loss)`.
+      #
+      def step(batch_size)
+        @optimizer.rescale_grad = @scale / batch_size
+        _update
+      end
 
-    def _update
-      @params.each.with_index do |param, i|
-        param.list_data.zip(param.list_grad) do |data, grad|
-          @optimizer.update(i, data, grad, nil)
+      ##
+      # Makes one step of parameter update.
+      #
+      # ====Parameter
+      #
+      # +batch_size+:: (integer)
+      #                Batch size of data processed. Gradient will be
+      #                normalized by `1/batch_size`. Set this to 1 if
+      #                you normalized loss manually with `loss =
+      #                mean(loss)`.
+      #
+      def update(batch_size)
+        @optimizer.rescale_grad = @scale / batch_size
+        _update
+      end
+
+      private
+
+      def check_contexts
+        contexts = nil
+        @params.each do |param|
+          unless contexts.nil? || contexts == param.list_ctx
+            raise RuntimeError,
+                  "All Parameters must be initialized on the same set of contexts, " \
+                  "but Parameter '#{param.name}' is initialized on '#{param.list_ctx.map(&:to_s)}' " \
+                  "while previous Parameters are initialized on '#{contexts.map(&:to_s)}'."
+          end
+          contexts = param.list_ctx
+        end
+        @contexts = contexts
+      end
+
+      def init_optimizer(optimizer, optimizer_params)
+        @optimizer = MXNet::Optimizer.create(optimizer, **optimizer_params)
+      end
+
+      def _update
+        @params.each.with_index do |param, i|
+          param.list_data.zip(param.list_grad) do |data, grad|
+            @optimizer.update(i, data, grad, nil)
+          end
         end
       end
     end

--- a/lib/mxnet/initializer.rb
+++ b/lib/mxnet/initializer.rb
@@ -22,10 +22,12 @@ module MXNet
       default = child.name.split('::').last.downcase
       child.register(default)
     end
+
     def self.register(name)
       $mxnet_initializer_registry ||= {}
       $mxnet_initializer_registry[name.to_sym] = self
     end
+
     def self.create(initializer)
       case initializer
       when ::Class
@@ -36,12 +38,14 @@ module MXNet
         initializer
       end
     end
+
     ##
     # Calls #init_array.
     #
     def [](array)
       init_array(array)
     end
+
     ##
     # Override to initialize array.
     #
@@ -52,6 +56,7 @@ module MXNet
     def init_array(array)
       raise NotImplementedError
     end
+
     ##
     # Initializes array to zero.
     #
@@ -61,9 +66,11 @@ module MXNet
         array[0..-1] = 0.0
       end
     end
+
     def self.Zero(*args)
       Zero.new(*args)
     end
+
     ##
     # Initializes array with random values uniformly sampled from a
     # given range.
@@ -82,13 +89,16 @@ module MXNet
       def initialize(scale = 0.07)
         @scale = scale
       end
+
       def init_array(array)
         MXNet::NDArray::Random.uniform(-@scale, @scale, out: array)
       end
     end
+
     def self.Uniform(*args)
       Uniform.new(*args)
     end
+
     ##
     # Initializes array with random values sampled from a normal
     # distribution with a mean of zero and standard deviation of
@@ -107,10 +117,12 @@ module MXNet
       def initialize(sigma = 0.01)
         @sigma = sigma
       end
+
       def init_array(array)
         MXNet::NDArray::Random.normal(0, @sigma, out: array)
       end
     end
+
     def self.Normal(*args)
       Normal.new(*args)
     end

--- a/lib/mxnet/initializer.rb
+++ b/lib/mxnet/initializer.rb
@@ -42,7 +42,7 @@ module MXNet
     ##
     # Calls #init_array.
     #
-    def [](array)
+    def call(array)
       init_array(array)
     end
 

--- a/lib/mxnet/initializer.rb
+++ b/lib/mxnet/initializer.rb
@@ -4,7 +4,38 @@ module MXNet
   ##
   # The base class of an initializer.
   #
+  # Custom initializers can be created by subclassing Initializer and
+  # implementing the required function #init_array. By default, the
+  # created initializer will be registered under its simplified class
+  # name (`class.name.split('::').last.downcase.to_sym`) but it may be
+  # registered under another name by calling #register.
+  #
+  #     class CustomInit < Initializer
+  #       register :myinit
+  #       def init_array(array)
+  #         array[0..-1] = 1.0
+  #       end
+  #     end
+  #
   class Initializer
+    def self.inherited(child)
+      default = child.name.split('::').last.downcase
+      child.register(default)
+    end
+    def self.register(name)
+      $mxnet_initializer_registry ||= {}
+      $mxnet_initializer_registry[name.to_sym] = self
+    end
+    def self.create(initializer)
+      case initializer
+      when ::Class
+        initializer.new
+      when ::String, ::Symbol
+        $mxnet_initializer_registry[initializer.to_sym].new
+      else
+        initializer
+      end
+    end
     ##
     # Calls #init_array.
     #
@@ -21,49 +52,67 @@ module MXNet
     def init_array(array)
       raise NotImplementedError
     end
-  end
-  ##
-  # Initializes weights with random values uniformly sampled from a
-  # given range.
-  #
-  class Uniform < Initializer
     ##
-    # Creates a new instance.
+    # Initializes array to zero.
     #
-    # ====Parameters
-    #
-    # +scale+:: (Float, optional)
-    #           The bound on the range of the generated random values.
-    #           Values are generated from the range <tt>[-scale, scale]</tt>.
-    #           Default scale is 0.07.
-    #
-    def initialize(scale = 0.07)
-      @scale = scale
+    class Zero < Initializer
+      register :zeros
+      def init_array(array)
+        array[0..-1] = 0.0
+      end
     end
-    def init_array(array)
-      MXNet::NDArray::Random.uniform(-@scale, @scale, out: array)
+    def self.Zero(*args)
+      Zero.new(*args)
     end
-  end
-  ##
-  # Initializes weights with random values sampled from a normal
-  # distribution with a mean of zero and standard deviation of
-  # +sigma+.
-  #
-  class Normal < Initializer
     ##
-    # Creates a new instance.
+    # Initializes array with random values uniformly sampled from a
+    # given range.
     #
-    # ====Parameters
-    #
-    # +sigma+:: (Float, optional)
-    #           Standard deviation of the normal distribution.
-    #           Default standard deviation is 0.01.
-    #
-    def initialize(sigma = 0.01)
-      @sigma = sigma
+    class Uniform < Initializer
+      ##
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +scale+:: (Float, optional)
+      #           The bound on the range of the generated random values.
+      #           Values are generated from the range <tt>[-scale, scale]</tt>.
+      #           Default scale is 0.07.
+      #
+      def initialize(scale = 0.07)
+        @scale = scale
+      end
+      def init_array(array)
+        MXNet::NDArray::Random.uniform(-@scale, @scale, out: array)
+      end
     end
-    def init_array(array)
-      MXNet::NDArray::Random.normal(0, @sigma, out: array)
+    def self.Uniform(*args)
+      Uniform.new(*args)
+    end
+    ##
+    # Initializes array with random values sampled from a normal
+    # distribution with a mean of zero and standard deviation of
+    # +sigma+.
+    #
+    class Normal < Initializer
+      ##
+      # Creates a new instance.
+      #
+      # ====Parameters
+      #
+      # +sigma+:: (Float, optional)
+      #           Standard deviation of the normal distribution.
+      #           Default standard deviation is 0.01.
+      #
+      def initialize(sigma = 0.01)
+        @sigma = sigma
+      end
+      def init_array(array)
+        MXNet::NDArray::Random.normal(0, @sigma, out: array)
+      end
+    end
+    def self.Normal(*args)
+      Normal.new(*args)
     end
   end
 end

--- a/lib/mxnet/initializer.rb
+++ b/lib/mxnet/initializer.rb
@@ -1,0 +1,69 @@
+require 'mxnet'
+
+module MXNet
+  ##
+  # The base class of an initializer.
+  #
+  class Initializer
+    ##
+    # Calls #init_array.
+    #
+    def [](array)
+      init_array(array)
+    end
+    ##
+    # Override to initialize array.
+    #
+    # ====Parameters
+    #
+    # +array+:: (NDArray) Array to initialize.
+    #
+    def init_array(array)
+      raise NotImplementedError
+    end
+  end
+  ##
+  # Initializes weights with random values uniformly sampled from a
+  # given range.
+  #
+  class Uniform < Initializer
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +scale+:: (Float, optional)
+    #           The bound on the range of the generated random values.
+    #           Values are generated from the range <tt>[-scale, scale]</tt>.
+    #           Default scale is 0.07.
+    #
+    def initialize(scale = 0.07)
+      @scale = scale
+    end
+    def init_array(array)
+      MXNet::NDArray::Random.uniform(-@scale, @scale, out: array)
+    end
+  end
+  ##
+  # Initializes weights with random values sampled from a normal
+  # distribution with a mean of zero and standard deviation of
+  # +sigma+.
+  #
+  class Normal < Initializer
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +sigma+:: (Float, optional)
+    #           Standard deviation of the normal distribution.
+    #           Default standard deviation is 0.01.
+    #
+    def initialize(sigma = 0.01)
+      @sigma = sigma
+    end
+    def init_array(array)
+      MXNet::NDArray::Random.normal(0, @sigma, out: array)
+    end
+  end
+end

--- a/lib/mxnet/optimizer.rb
+++ b/lib/mxnet/optimizer.rb
@@ -1,0 +1,113 @@
+require 'mxnet'
+
+module MXNet
+  ##
+  # The base class inherited by all optimizers.
+  #
+  class Optimizer
+    ##
+    # Creates a new instance.
+    #
+    # ====Parameters
+    #
+    # +rescale_grad+::  (float, optional)
+    #                   Before updating, multiply the gradient with
+    #                   "rescale_grad". Often choose to be
+    #                   <tt>1.0/batch_size</tt>.
+    # +learning_rate+:: (float, optional)
+    #                   The initial learning rate.
+    # +wd+::            (float, optional)
+    #                   The weight decay (or L2 regularization)
+    #                   coefficient. Modifies objective by adding a
+    #                   penalty for having large weights.
+    #
+    def initialize(rescale_grad: 1.0, learning_rate: 0.01, wd: 0.0)
+      @rescale_grad = rescale_grad
+      @lr = learning_rate
+      @wd = wd
+    end
+    attr_accessor :rescale_grad
+    ##
+    # Updates the given parameter using the corresponding gradient and
+    # state.
+    #
+    # ====Parameters
+    #
+    # +index+::    (integer)
+    #              The unique index of the parameter into the
+    #              individual learning rates and weight
+    #              decays. Learning rates and weight decay may be set
+    #              via #set_lr_mult and #set_wd_mult, respectively.
+    # +weight+::   (NDArray)
+    #              The parameter to be updated.
+    # +gradient+:: (NDArray)
+    #              The gradient of the objective with respect to this
+    #              parameter.
+    # +state+::    (any)
+    #              The state returned by #create_state.
+    #
+    def update(index, weight, gradient, state)
+      raise NotImplementedError
+    end
+    protected
+    ##
+    # Gets the learning rate given the index of the weight.
+    #
+    # ====Parameters
+    #
+    # +index+:: (integer)
+    #           The index corresponding to the weight.
+    #
+    # ====Returns
+    #
+    # Learning rate for this index.
+    #
+    def get_lr(index)
+      @lr
+    end
+    ##
+    # Gets weight decay for index.
+    #
+    # ====Parameters
+    #
+    # +index+:: (integer)
+    #           The index corresponding to the weight.
+    #
+    # ====Returns
+    #
+    # Weight decay for this index.
+    #
+    def get_wd(index)
+      @wd
+    end
+  end
+  ##
+  # The SGD optimizer with momentum and weight decay.
+  #
+  class SGD < Optimizer
+    ##
+    # Creates a new instance.
+    #
+    # This optimizer accepts the following parameters in addition to
+    # those accepted by Optimizer.
+    #
+    # ====Parameters
+    #
+    # +momentum+:: (float, optional)
+    #              The momentum value.
+    #
+    def initialize(momentum: 0.0, **kwargs)
+      super(**kwargs)
+      @momentum = momentum
+    end
+    def update(index, weight, gradient, state)
+      lr = get_lr(index)
+      wd = get_wd(index)
+      kwargs = {}.tap do |kwargs|
+        kwargs[:momentum] = @momentum if @momentum > 0
+        kwargs[:rescale_grad] = @rescale_grad
+      end
+      MXNet::NDArray.sgd_update(weight, gradient, out: weight, lr: lr, wd: wd, **kwargs)
+    end
+  end
+end

--- a/lib/mxnet/optimizer.rb
+++ b/lib/mxnet/optimizer.rb
@@ -22,10 +22,12 @@ module MXNet
       default = child.name.split('::').last.downcase
       child.register(default)
     end
+
     def self.register(name)
       $mxnet_optimizer_registry ||= {}
       $mxnet_optimizer_registry[name.to_sym] = self
     end
+
     def self.create(optimizer, **kwargs)
       case optimizer
       when ::Class
@@ -36,6 +38,7 @@ module MXNet
         optimizer
       end
     end
+
     ##
     # Creates a new instance.
     #
@@ -57,7 +60,9 @@ module MXNet
       @lr = learning_rate
       @wd = wd
     end
+
     attr_accessor :rescale_grad
+
     ##
     # Updates the given parameter using the corresponding gradient and
     # state.
@@ -80,37 +85,7 @@ module MXNet
     def update(index, weight, gradient, state)
       raise NotImplementedError
     end
-    protected
-    ##
-    # Gets the learning rate given the index of the weight.
-    #
-    # ====Parameters
-    #
-    # +index+:: (integer)
-    #           The index corresponding to the weight.
-    #
-    # ====Returns
-    #
-    # Learning rate for this index.
-    #
-    def get_lr(index)
-      @lr
-    end
-    ##
-    # Gets weight decay for index.
-    #
-    # ====Parameters
-    #
-    # +index+:: (integer)
-    #           The index corresponding to the weight.
-    #
-    # ====Returns
-    #
-    # Weight decay for this index.
-    #
-    def get_wd(index)
-      @wd
-    end
+
     ##
     # The SGD optimizer with momentum and weight decay.
     #
@@ -130,6 +105,7 @@ module MXNet
         super(**kwargs)
         @momentum = momentum
       end
+
       def update(index, weight, gradient, state)
         lr = get_lr(index)
         wd = get_wd(index)
@@ -140,8 +116,43 @@ module MXNet
         MXNet::NDArray.sgd_update(weight, gradient, out: weight, lr: lr, wd: wd, **kwargs)
       end
     end
+
     def self.SGD(*args)
       SGD.new(*args)
+    end
+
+    protected
+
+    ##
+    # Gets the learning rate given the index of the weight.
+    #
+    # ====Parameters
+    #
+    # +index+:: (integer)
+    #           The index corresponding to the weight.
+    #
+    # ====Returns
+    #
+    # Learning rate for this index.
+    #
+    def get_lr(index)
+      @lr
+    end
+
+    ##
+    # Gets weight decay for index.
+    #
+    # ====Parameters
+    #
+    # +index+:: (integer)
+    #           The index corresponding to the weight.
+    #
+    # ====Returns
+    #
+    # Weight decay for this index.
+    #
+    def get_wd(index)
+      @wd
     end
   end
 end

--- a/lib/mxnet/symbol.rb
+++ b/lib/mxnet/symbol.rb
@@ -78,7 +78,7 @@ module MXNet
     #     Error in operator fc1: Shape inconsistent, Provided=[1, 100], inferred shape=[1000, 100]
     #
     # @param *args  Shape of arguments in a positional way. Unknown shape can be marked as nil.
-    # @param **kwargs  Keyword arguments of the knwon shapes.
+    # @param **kwargs  Keyword arguments of the known shapes.
     #
     # @return [Array<Array<Array, nil>>]  Three arrays of argument shapes.
     #   The first array is array of argument shapes.
@@ -126,7 +126,7 @@ module MXNet
     # NATIVE: save
     # NATIVE: to_json
 
-    # Evaluates a symbol given argumens.
+    # Evaluates a symbol given arguments.
     #
     # The `eval` method combines a call to `bind` (which returns an executer)
     # with a call to `forward` (executor method).

--- a/lib/mxnet/symbol.rb
+++ b/lib/mxnet/symbol.rb
@@ -353,7 +353,12 @@ module MXNet
       attr[:__shape__] = shape.to_s if shape
       attr[:__lr_mult__] = lr_mult.to_s if lr_mult
       attr[:__wd_mult__] = wd_mult.to_s if wd_mult
-      attr[:__dtype__] = MXNet::DType.name2id(dtype).to_s if dtype
+      case dtype
+      when ::Integer
+        attr[:__dtype__] = dtype.to_s
+      when ::String, ::Symbol
+        attr[:__dtype__] = MXNet::DType.name2id(dtype).to_s
+      end
       if init
         init = init.to_json unless init.is_a?(String) || init.is_a?(::Symbol)
         attr[:__init__] = init

--- a/spec/mxnet/cached_op_spec.rb
+++ b/spec/mxnet/cached_op_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe MXNet::CachedOp do
+  describe '#new' do
+    let(:sym) do
+      MXNet::Symbol.var('sym')
+    end
+    it 'accepts keyword arguments' do
+      expect{MXNet::CachedOp.new(sym, static_alloc: 1)}.not_to raise_error
+      expect{MXNet::CachedOp.new(sym, data_indices: [0])}.not_to raise_error
+    end
+  end
+  describe '#call' do
+    let(:sym) do
+      MXNet::Symbol.var('sym')
+    end
+    let(:sqr) do
+      MXNet::CachedOp.new(sym * sym)
+    end
+    it 'squares the input' do
+      input = MXNet::NDArray.array([1, 2, 3])
+      expect(sqr.call(input).to_a).to eq([1, 4, 9])
+    end
+    it 'expects the correct number of inputs' do
+      inputs = [MXNet::NDArray.array([4, 5, 6]), MXNet::NDArray.array([7, 8, 9])]
+      expect{sqr.call(*inputs)}.to raise_error(MXNet::Error, /\(2 vs\. 1\)/)
+      expect{sqr.call()}.to raise_error(MXNet::Error, /\(0 vs\. 1\)/)
+    end
+  end
+end

--- a/spec/mxnet/cached_op_spec.rb
+++ b/spec/mxnet/cached_op_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe MXNet::CachedOp do
       expect{MXNet::CachedOp.new(sym, data_indices: [0])}.not_to raise_error
     end
   end
+
   describe '#call' do
     let(:sym) do
       MXNet::Symbol.var('sym')

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -4,12 +4,30 @@ require 'mxnet/gluon/parameter'
 require 'mxnet/ndarray'
 
 RSpec.describe MXNet::Gluon::Block do
+  describe 'assignment' do
+    let(:block) do
+      MXNet::Gluon::Block.new
+    end
+    it 'automagically creates a block accessor' do
+      a = block.a = MXNet::Gluon::Block.new
+      expect(block.a).to equal(a)
+    end
+    it 'automagically creates a parameter accessor' do
+      b = block.b = MXNet::Gluon::Parameter.new('b')
+      expect(block.b).to equal(b)
+    end
+  end
   describe '#collect_params' do
     let(:block) do
       MXNet::Gluon::Block.new.tap do |block|
         block.params.get('foo')
         block.params.get('bar')
         block.params.get('baz')
+      end
+    end
+    let(:child) do
+      MXNet::Gluon::Block.new.tap do |block|
+        block.params.get('qoz')
       end
     end
     it 'returns all its parameters' do
@@ -26,6 +44,13 @@ RSpec.describe MXNet::Gluon::Block do
         params.get('baz')
       end
       expect(block.collect_params(/_ba/)).to eq(params)
+    end
+    it 'returns matching parameters from children' do
+      block.qoz = child
+      params = MXNet::Gluon::ParameterDict.new(prefix: 'block_').tap do |params|
+        params.get('qoz')
+      end
+      expect(block.collect_params(/_q/)).to eq(params)
     end
   end
   describe '#forward' do

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -6,7 +6,7 @@ require 'mxnet/ndarray'
 RSpec.describe MXNet::Gluon::Block do
   describe 'assignment' do
     let(:block) do
-      MXNet::Gluon::Block.new
+      described_class.new
     end
     it 'raises exception if accessor is undefined' do
       expect{block.b}.to raise_error(NoMethodError)
@@ -16,7 +16,7 @@ RSpec.describe MXNet::Gluon::Block do
       expect{block.send(:b=)}.to raise_error(ArgumentError)
     end
     it 'automagically defines a block accessor' do
-      a = block.a = MXNet::Gluon::Block.new
+      a = block.a = described_class.new
       expect(block.a).to equal(a)
     end
     it 'automagically defines a parameter accessor' do
@@ -26,15 +26,15 @@ RSpec.describe MXNet::Gluon::Block do
   end
   describe '#new' do
     let(:block) do
-      MXNet::Gluon::Block.new
+      described_class.new
     end
     it 'assigns a unique prefix' do
       expect(block.prefix).to match(/^block[0-9]+_$/)
-      expect(block.prefix).not_to eq(MXNet::Gluon::Block.new.prefix)
+      expect(block.prefix).not_to eq(described_class.new.prefix)
     end
     context 'with prefix' do
       let(:block) do
-        MXNet::Gluon::Block.new(prefix: 'foo')
+        described_class.new(prefix: 'foo')
       end
       it 'uses the assigned prefix' do
         expect(block.prefix).to eq('foo')
@@ -47,7 +47,7 @@ RSpec.describe MXNet::Gluon::Block do
         end
       end
       let(:block) do
-        MXNet::Gluon::Block.new(params: params)
+        described_class.new(params: params)
       end
       it 'shares the assigned params' do
         expect(block.params.get('foo')).to equal(params.get('foo'))
@@ -56,13 +56,13 @@ RSpec.describe MXNet::Gluon::Block do
   end
   describe '#with_name_scope' do
     let(:block) do
-      MXNet::Gluon::Block.new
+      described_class.new
     end
     it 'prepends prefixes to scoped blocks' do
       block.with_name_scope do
-        block.foo = MXNet::Gluon::Block.new
+        block.foo = described_class.new
         block.foo.with_name_scope do
-          block.foo.bar = MXNet::Gluon::Block.new
+          block.foo.bar = described_class.new
         end
       end
       expect(block.foo.prefix).to match(/^block[0-9]+_block0_$/)
@@ -71,14 +71,14 @@ RSpec.describe MXNet::Gluon::Block do
   end
   describe '#collect_params' do
     let(:block) do
-      MXNet::Gluon::Block.new(prefix: 'block_').tap do |block|
+      described_class.new(prefix: 'block_').tap do |block|
         block.params.get('foo')
         block.params.get('bar')
         block.params.get('baz')
       end
     end
     let(:child) do
-      MXNet::Gluon::Block.new(prefix: 'block_').tap do |block|
+      described_class.new(prefix: 'block_').tap do |block|
         block.params.get('qoz')
       end
     end
@@ -107,7 +107,7 @@ RSpec.describe MXNet::Gluon::Block do
   end
   describe '#forward' do
     let(:block) do
-      MXNet::Gluon::Block.new
+      described_class.new
     end
     it 'is not implemented' do
       expect{block.forward(MXNet::NDArray.array([]))}.to raise_error(NotImplementedError)
@@ -118,7 +118,7 @@ end
 RSpec.describe MXNet::Gluon::HybridBlock do
   describe '#forward' do
     let(:block) do
-      MXNet::Gluon::HybridBlock.new
+      described_class.new
     end
     it 'is not implemented' do
       expect{block.forward(MXNet::NDArray.array([]))}.to raise_error(NotImplementedError)
@@ -126,7 +126,7 @@ RSpec.describe MXNet::Gluon::HybridBlock do
   end
   context 'given a simple model' do
     before do
-      stub_const 'Foo', Class.new(MXNet::Gluon::HybridBlock)
+      stub_const 'Foo', Class.new(described_class)
       Foo.class_eval do
         def initialize(**kwargs)
           super

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -172,11 +172,11 @@ RSpec.describe MXNet::Gluon::Block do
           block.init
         end
       end
-      it 'to raise error about missing parameter' do
+      it 'raises error about missing parameter' do
         expect{block.load_parameters(file, ignore_extra: true)}
           .to raise_error(RuntimeError, /allow_missing: true/)
       end
-      it 'to raise error about extra parameter' do
+      it 'raises error about extra parameter' do
         expect{block.load_parameters(file, allow_missing: true)}
           .to raise_error(RuntimeError, /ignore_extra: true/)
       end
@@ -220,7 +220,9 @@ RSpec.describe MXNet::Gluon::HybridBlock do
       Foo.class_eval do
         def initialize(**kwargs)
           super
-          self.c = params.get('c', allow_deferred_init: true, dtype: nil)
+          with_name_scope do
+            self.c = params.get('c', init: :zeros, allow_deferred_init: true, dtype: nil)
+          end
         end
         def hybrid_forward(clazz, i, **kwargs)
           c = kwargs[:c]
@@ -249,6 +251,36 @@ RSpec.describe MXNet::Gluon::HybridBlock do
         expect(foo.c.dtype).to eq(data.dtype)
       end
     end
+    describe '#export' do
+      let(:file) do
+        Tempfile.new('foo').path
+      end
+      let(:data) do
+        ['120100000000000000000000000000000100000000000000c9fa93f900000000' \
+         '0100000002000000000000000100000000000000000000000000000000000000' \
+         '01000000000000000a000000000000006172673a746573745f63'
+        ].pack('H*').force_encoding('utf-8')
+      end
+      let(:foo) do
+        Foo.new(prefix: 'test_').tap do |foo|
+          foo.init
+          foo.forward(MXNet::NDArray.array([1, 2]))
+        end
+      end
+      it 'writes model data to a file' do
+        foo.export(file)
+        expect(JSON.parse(File.open('%s-symbol.json' % file).read))
+          .to include({'nodes' => include(
+                         include({'name' => match(/_plus[0-9]+/)}),
+                         include({'name' => 'test_c'}),
+                         include({'name' => 'data0'})
+                       )})
+      end
+      it 'writes parameter data to a file' do
+        foo.export(file)
+        expect(File.open('%s-0000.params' % file).read).to eq(data)
+      end
+    end
   end
 end
 
@@ -264,6 +296,63 @@ RSpec.describe MXNet::Gluon::SymbolBlock do
   end
   let(:o) do
     i * w + b
+  end
+  describe '.import' do
+    let(:file) do
+      Tempfile.new('foo').path
+    end
+    let(:model) do
+      {nodes: [
+         {op: 'null', name: 'data', inputs: []},
+         {op: 'null', name: 'test_c', inputs: []},
+         {op: 'elemwise_add', name: 'test_plus0', inputs: [[0, 0, 0], [1, 0, 0]]}
+       ],
+       arg_nodes: [0, 1],
+       node_row_ptr: [0, 1, 2, 3],
+       heads: [[2, 0, 0]],
+       attrs: {mxnet_version: ['int', 10100]}
+      }.to_json
+    end
+    let(:data) do
+      ['120100000000000000000000000000000100000000000000c9fa93f900000000' \
+       '010000000200000000000000010000000000000000000000e0eedf3b98f6543c' \
+       '01000000000000000a000000000000006172673a746573745f63'
+      ].pack('H*').force_encoding('utf-8')
+    end
+    let(:block) do
+      described_class.import(file, 'data')
+    end
+    before do
+      File.open('%s-symbol.json' % file, 'wb') { |f| f.write(model) }
+      File.open('%s-0000.params' % file, 'wb') { |f| f.write(data) }
+    end
+    it 'loads the parameter data' do
+      expect(block.params.get('test_c').data.to_a)
+        .to match_array([
+                          be_within(0.0001).of(0.0068339),
+                          be_within(0.0001).of(0.0129982)
+                        ])
+    end
+    it 'evaluates the symbolized block' do
+      expect(block.forward(MXNet::NDArray.array([1, 1])).to_a)
+        .to match_array([
+                          be_within(0.0001).of(1.0068339),
+                          be_within(0.0001).of(1.0129982)
+                        ])
+    end
+    context 'with mismatched parameters' do
+      before do
+        File.open('%s-symbol.json' % file, 'wb') { |f| f.write(model.gsub('test_c', 'foo_c')) }
+      end
+      it 'raises error about missing parameter' do
+        expect{described_class.import(file, 'data', ignore_extra: true)}
+          .to raise_error(RuntimeError, /allow_missing: true/)
+      end
+      it 'raises error about extra parameter' do
+        expect{described_class.import(file, 'data', allow_missing: true)}
+          .to raise_error(RuntimeError, /ignore_extra: true/)
+      end
+    end
   end
   describe '.new' do
     let(:layer) do

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'mxnet/gluon/block'
+require 'mxnet/gluon/parameter'
+require 'mxnet/ndarray'
+
+RSpec.describe MXNet::Gluon::Block do
+  describe '#collect_params' do
+    let(:block) do
+      MXNet::Gluon::Block.new.tap do |block|
+        block.params.get('foo')
+        block.params.get('bar')
+        block.params.get('baz')
+      end
+    end
+    it 'returns all its parameters' do
+      params = MXNet::Gluon::ParameterDict.new(prefix: 'block_').tap do |params|
+        params.get('foo')
+        params.get('bar')
+        params.get('baz')
+      end
+      expect(block.collect_params).to eq(params)
+    end
+    it 'returns the matching parameters' do
+      params = MXNet::Gluon::ParameterDict.new(prefix: 'block_').tap do |params|
+        params.get('bar')
+        params.get('baz')
+      end
+      expect(block.collect_params(/_ba/)).to eq(params)
+    end
+  end
+  describe '#forward' do
+    let(:block) do
+      MXNet::Gluon::Block.new
+    end
+    it 'is not implemented' do
+      expect{block.forward(MXNet::NDArray.array([]))}.to raise_error(NotImplementedError)
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::HybridBlock do
+  describe '#forward' do
+    let(:block) do
+      MXNet::Gluon::HybridBlock.new
+    end
+    it 'is not implemented' do
+      expect{block.forward(MXNet::NDArray.array([]))}.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tempfile'
 require 'mxnet/gluon/block'
 require 'mxnet/gluon/parameter'
 require 'mxnet/ndarray'
@@ -114,6 +115,71 @@ RSpec.describe MXNet::Gluon::Block do
         params.get('qoz')
       end
       expect(block.collect_params(/_q/)).to eq(params)
+    end
+  end
+  describe '#save_parameters' do
+    let(:file) do
+      Tempfile.new('foo').path
+    end
+    let(:data) do
+      ['120100000000000000000000000000000100000000000000c9fa93f900000000' \
+       '0100000002000000000000000100000000000000000000000000000000000000' \
+       '01000000000000000300000000000000666f6f'
+      ].pack('H*').force_encoding('utf-8')
+    end
+    let(:block) do
+      described_class.new.tap do |block|
+        block.foo = block.params.get('foo', shape: [2], init: :zeros)
+        block.init
+      end
+    end
+    it 'creates a file with the parameter data' do
+      block.save_parameters(file)
+      expect(File.open(file).read).to eq(data)
+    end
+  end
+  describe '#load_parameters' do
+    let(:file) do
+      Tempfile.new('foo').path
+    end
+    let(:data) do
+      ['120100000000000000000000000000000100000000000000c9fa93f900000000' \
+       '01000000020000000000000001000000000000000000000098f6543cdccbf63c' \
+       '01000000000000000300000000000000666f6f'
+      ].pack('H*').force_encoding('utf-8')
+    end
+    let(:block) do
+      described_class.new.tap do |block|
+        block.foo = block.params.get('foo', shape: [2], init: :zeros)
+        block.init
+      end
+    end
+    before do
+      File.open(file, 'wb') { |f| f.write(data) }
+    end
+    it 'loads parameter data from a file' do
+      block.load_parameters(file)
+      expect(block.foo.data.to_a)
+        .to match_array([
+                          be_within(0.0001).of(0.0129982),
+                          be_within(0.0001).of(0.0301265)
+                        ])
+    end
+    context 'with mismatched parameters' do
+      let(:block) do
+        described_class.new.tap do |block|
+          block.bar = block.params.get('bar', shape: [2], init: :zeros)
+          block.init
+        end
+      end
+      it 'to raise error about missing parameter' do
+        expect{block.load_parameters(file, ignore_extra: true)}
+          .to raise_error(RuntimeError, /allow_missing: true/)
+      end
+      it 'to raise error about extra parameter' do
+        expect{block.load_parameters(file, allow_missing: true)}
+          .to raise_error(RuntimeError, /ignore_extra: true/)
+      end
     end
   end
   describe '#forward' do

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -117,4 +117,40 @@ RSpec.describe MXNet::Gluon::HybridBlock do
       expect{block.forward(MXNet::NDArray.array([]))}.to raise_error(NotImplementedError)
     end
   end
+  context 'given a simple model' do
+    before do
+      stub_const 'Foo', Class.new(MXNet::Gluon::HybridBlock)
+      Foo.class_eval do
+        def initialize(**kwargs)
+          super
+          self.c = params.get('c', allow_deferred_init: true, dtype: nil)
+        end
+        def hybrid_forward(clazz, i, **kwargs)
+          c = kwargs[:c]
+          i + c
+        end
+      end
+    end
+    let(:foo) do
+      Foo.new
+    end
+    describe '#infer_shape' do
+      let(:data) do
+        MXNet::NDArray.array([1, 2, 3, 4]).reshape([2, 2])
+      end
+      it 'should infer the shape' do
+        foo.infer_shape(data)
+        expect(foo.c.shape).to eq(data.shape)
+      end
+    end
+    describe '#infer_type' do
+      let(:data) do
+        MXNet::NDArray.array([1], dtype: :float16)
+      end
+      it 'should infer the type' do
+        foo.infer_type(data)
+        expect(foo.c.dtype).to eq(data.dtype)
+      end
+    end
+  end
 end

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe MXNet::Gluon::Block do
       expect(block.b).to equal(b)
     end
   end
+
   describe '#new' do
     let(:block) do
       described_class.new
@@ -55,6 +56,7 @@ RSpec.describe MXNet::Gluon::Block do
       end
     end
   end
+
   describe '#with_name_scope' do
     let(:block) do
       described_class.new
@@ -70,6 +72,7 @@ RSpec.describe MXNet::Gluon::Block do
       expect(block.foo.bar.prefix).to match(/^block[0-9]+_block0_block0_$/)
     end
   end
+
   describe '#init' do
     let(:block) do
       described_class.new.tap do |block|
@@ -81,6 +84,7 @@ RSpec.describe MXNet::Gluon::Block do
       expect(block.params.get('foo').data).to be_a(MXNet::NDArray)
     end
   end
+
   describe '#collect_params' do
     let(:block) do
       described_class.new(prefix: 'block_').tap do |block|
@@ -117,6 +121,7 @@ RSpec.describe MXNet::Gluon::Block do
       expect(block.collect_params(/_q/)).to eq(params)
     end
   end
+
   describe '#save_parameters' do
     let(:file) do
       Tempfile.new('foo').path
@@ -138,6 +143,7 @@ RSpec.describe MXNet::Gluon::Block do
       expect(File.open(file).read).to eq(data)
     end
   end
+
   describe '#load_parameters' do
     let(:file) do
       Tempfile.new('foo').path
@@ -182,6 +188,7 @@ RSpec.describe MXNet::Gluon::Block do
       end
     end
   end
+
   describe '#forward' do
     let(:block) do
       described_class.new
@@ -214,6 +221,7 @@ RSpec.describe MXNet::Gluon::HybridBlock do
       end
     end
   end
+
   context 'given a simple model' do
     before do
       stub_const 'Foo', Class.new(described_class)
@@ -233,6 +241,7 @@ RSpec.describe MXNet::Gluon::HybridBlock do
     let(:foo) do
       Foo.new
     end
+
     describe '#infer_shape' do
       let(:data) do
         MXNet::NDArray.array([1, 2, 3, 4]).reshape([2, 2])
@@ -242,6 +251,7 @@ RSpec.describe MXNet::Gluon::HybridBlock do
         expect(foo.c.shape).to eq(data.shape)
       end
     end
+
     describe '#infer_type' do
       let(:data) do
         MXNet::NDArray.array([1], dtype: :float16)
@@ -251,6 +261,7 @@ RSpec.describe MXNet::Gluon::HybridBlock do
         expect(foo.c.dtype).to eq(data.dtype)
       end
     end
+
     describe '#export' do
       let(:file) do
         Tempfile.new('foo').path
@@ -297,6 +308,7 @@ RSpec.describe MXNet::Gluon::SymbolBlock do
   let(:o) do
     i * w + b
   end
+
   describe '.import' do
     let(:file) do
       Tempfile.new('foo').path
@@ -354,6 +366,7 @@ RSpec.describe MXNet::Gluon::SymbolBlock do
       end
     end
   end
+
   describe '.new' do
     let(:layer) do
       described_class.new(o, [i])
@@ -366,6 +379,7 @@ RSpec.describe MXNet::Gluon::SymbolBlock do
       expect(layer.b).to be_a(MXNet::Gluon::Parameter)
     end
   end
+
   describe '#forward' do
     let(:layer) do
       described_class.new(o, [i]).tap do |layer|

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe MXNet::Gluon::Block do
       expect(block.foo.bar.prefix).to match(/^block[0-9]+_block0_block0_$/)
     end
   end
+  describe '#init' do
+    let(:block) do
+      described_class.new.tap do |block|
+        block.params.get('foo', shape: 1)
+      end
+    end
+    it 'initializes all parameters' do
+      block.init
+      expect(block.params.get('foo').data).to be_a(MXNet::NDArray)
+    end
+  end
   describe '#collect_params' do
     let(:block) do
       described_class.new(prefix: 'block_').tap do |block|

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe MXNet::Gluon::HybridBlock do
           .to include({'nodes' => include(
                          include({'name' => match(/_plus[0-9]+/)}),
                          include({'name' => 'test_c'}),
-                         include({'name' => 'data0'})
+                         include({'name' => 'data'})
                        )})
       end
       it 'writes parameter data to a file' do

--- a/spec/mxnet/gluon/block_spec.rb
+++ b/spec/mxnet/gluon/block_spec.rb
@@ -8,11 +8,18 @@ RSpec.describe MXNet::Gluon::Block do
     let(:block) do
       MXNet::Gluon::Block.new
     end
-    it 'automagically creates a block accessor' do
+    it 'raises exception if accessor is undefined' do
+      expect{block.b}.to raise_error(NoMethodError)
+    end
+    it 'raises exception if called with too many arguments' do
+      expect{block.send(:b, 1)}.to raise_error(ArgumentError)
+      expect{block.send(:b=)}.to raise_error(ArgumentError)
+    end
+    it 'automagically defines a block accessor' do
       a = block.a = MXNet::Gluon::Block.new
       expect(block.a).to equal(a)
     end
-    it 'automagically creates a parameter accessor' do
+    it 'automagically defines a parameter accessor' do
       b = block.b = MXNet::Gluon::Parameter.new('b')
       expect(block.b).to equal(b)
     end

--- a/spec/mxnet/gluon/data/data_loader_spec.rb
+++ b/spec/mxnet/gluon/data/data_loader_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+require 'mxnet/gluon/data/data_loader'
+
+RSpec.describe MXNet::Gluon::Data::DataLoader do
+  let(:dataset) do
+    (0..99).to_a
+  end
+  let(:shuffle) do
+    false
+  end
+  let(:batch_size) do
+    3
+  end
+  let(:last_batch) do
+    :keep
+  end
+  let(:loader) do
+    described_class.new(dataset, shuffle: shuffle, batch_size: batch_size, last_batch: last_batch)
+  end
+
+  describe '#length' do
+    it 'is 34 (mini-batches)' do
+      expect(loader.length).to eq(34)
+    end
+  end
+
+  describe '#each' do
+    it 'results in an array of slices' do
+      expect(loader.each.map(&:to_a)).to eq((0..99).each_slice(3).to_a)
+    end
+  end
+
+  context 'with `shuffle: true`' do
+    let(:shuffle) do
+      true
+    end
+
+    describe '#length' do
+      it 'is 4 (mini-batches)' do
+        expect(loader.length).to eq(34)
+      end
+    end
+
+    describe '#each' do
+      it 'results in an array out of sequence' do
+        expect(loader.each.map(&:to_a)).not_to eq((0..99).each_slice(3).to_a)
+      end
+    end
+  end
+
+  context 'with `batch_size: 10`' do
+    let(:batch_size) do
+      10
+    end
+
+    describe '#length' do
+      it 'is 10 (mini-batches)' do
+        expect(loader.length).to eq(10)
+      end
+    end
+
+    describe '#each' do
+      it 'results in an array of slices' do
+        expect(loader.each.map(&:to_a)).to eq((0..99).each_slice(10).to_a)
+      end
+    end
+  end
+
+  context 'with `last_batch: :discard`' do
+    let(:last_batch) do
+      :discard
+    end
+
+    describe '#length' do
+      it 'is 33 (mini-batches)' do
+        expect(loader.length).to eq(33)
+      end
+    end
+
+    describe '#each' do
+      it 'results in an array of slices' do
+        expect(loader.each.map(&:to_a)).to eq((0..98).each_slice(3).to_a)
+      end
+    end
+  end
+
+  context 'with `last_batch: :rollover`' do
+    let(:last_batch) do
+      :rollover
+    end
+
+    before do
+      loader.to_a
+    end
+
+    describe '#length' do
+      it 'is 33 (mini-batches)' do
+        expect(loader.length).to eq(33)
+      end
+    end
+
+    describe '#each' do
+      it 'results in an array of slices' do
+        expect(loader.each.map(&:to_a)).to eq((0..99).to_a.rotate(-1).each_slice(3).to_a[0..-2])
+      end
+    end
+  end
+end

--- a/spec/mxnet/gluon/data/sampler_spec.rb
+++ b/spec/mxnet/gluon/data/sampler_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+require 'mxnet/gluon/data/sampler'
+
+RSpec.describe MXNet::Gluon::Data::SequentialSampler do
+  let(:sampler) do
+    described_class.new(100)
+  end
+
+  describe '#length' do
+    it 'is 100' do
+      expect(sampler.length).to eq(100)
+    end
+  end
+
+  describe '#each' do
+    it 'results in an array from 0 to 99 in sequence' do
+      expect(sampler.each.to_a).to eq((0..99).to_a)
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::Data::RandomSampler do
+  let(:sampler) do
+    described_class.new(100)
+  end
+
+  describe '#length' do
+    it 'is 100' do
+      expect(sampler.length).to eq(100)
+    end
+  end
+
+  describe '#each' do
+    it 'results in an array from 0 to 99 out of sequence' do
+      expect(sampler.each.to_a).not_to eq((0..99).to_a)
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::Data::BatchSampler do
+  context 'with `last_batch = :keep`' do
+    let(:sampler) do
+      sampler = MXNet::Gluon::Data.SequentialSampler(10)
+      described_class.new(sampler, 3, :keep)
+    end
+
+    describe '#length' do
+      it 'is 4 (mini-batches)' do
+        expect(sampler.length).to eq(4)
+      end
+    end
+
+    describe '#each' do
+      it 'results in a final partial batch' do
+        expect(sampler.each.to_a).to eq([[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]])
+      end
+    end
+  end
+
+  context 'with `last_batch = :discard`' do
+    let(:sampler) do
+      sampler = MXNet::Gluon::Data.SequentialSampler(10)
+      described_class.new(sampler, 3, :discard)
+    end
+
+    describe '#length' do
+      it 'is 3 (mini-batches)' do
+        expect(sampler.length).to eq(3)
+      end
+    end
+
+    describe '#each' do
+      it 'results in an omitted final batch' do
+        expect(sampler.each.to_a).to eq([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+      end
+    end
+  end
+
+  context 'with `last_batch = :rollover`' do
+    let(:sampler) do
+      sampler = MXNet::Gluon::Data.SequentialSampler(10)
+      described_class.new(sampler, 3, :rollover).tap do |sampler|
+        2.times { sampler.to_a }
+      end
+    end
+
+    describe '#length' do
+      it 'is 3 (mini-batches)' do
+        expect(sampler.length).to eq(4)
+      end
+    end
+
+    describe '#each' do
+      it 'results in a rolled-over final batch' do
+        expect(sampler.each.to_a).to eq([[8, 9, 0], [1, 2, 3], [4, 5, 6], [7, 8, 9]])
+      end
+    end
+  end
+end

--- a/spec/mxnet/gluon/loss_spec.rb
+++ b/spec/mxnet/gluon/loss_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'mxnet/gluon/loss'
+
+RSpec.describe MXNet::Gluon::L2Loss do
+  describe '#hybrid_forward' do
+    let(:loss) do
+      MXNet::Gluon::L2Loss.new
+    end
+    it 'calculates L2 loss' do
+      prediction = MXNet::NDArray.array([1])
+      label = MXNet::NDArray.array([2])
+      expect(loss.hybrid_forward(MXNet::NDArray, prediction, label).to_a).to eq([0.5])
+    end
+  end
+end

--- a/spec/mxnet/gluon/loss_spec.rb
+++ b/spec/mxnet/gluon/loss_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 require 'mxnet/gluon/loss'
 
-RSpec.describe MXNet::Gluon::L2Loss do
+RSpec.describe MXNet::Gluon::Loss::L2Loss do
   describe '#hybrid_forward' do
     let(:loss) do
-      MXNet::Gluon::L2Loss.new
+      MXNet::Gluon::Loss::L2Loss.new
     end
     it 'calculates L2 loss' do
       prediction = MXNet::NDArray.array([1])

--- a/spec/mxnet/gluon/loss_spec.rb
+++ b/spec/mxnet/gluon/loss_spec.rb
@@ -2,40 +2,40 @@ require 'spec_helper'
 require 'mxnet/gluon/loss'
 
 RSpec.describe MXNet::Gluon::Loss::L1Loss do
-  describe '#[]' do
+  describe '#call' do
     let(:loss) do
       described_class.new
     end
     it 'calculates L1 loss' do
       prediction = MXNet::NDArray.array([1])
       label = MXNet::NDArray.array([2])
-      expect(loss[prediction, label].as_scalar).to eq(1.0)
+      expect(loss.call(prediction, label).as_scalar).to eq(1.0)
     end
   end
 end
 
 RSpec.describe MXNet::Gluon::Loss::L2Loss do
-  describe '#[]' do
+  describe '#call' do
     let(:loss) do
       described_class.new
     end
     it 'calculates L2 loss' do
       prediction = MXNet::NDArray.array([1])
       label = MXNet::NDArray.array([2])
-      expect(loss[prediction, label].as_scalar).to eq(0.5)
+      expect(loss.call(prediction, label).as_scalar).to eq(0.5)
     end
   end
 end
 
 RSpec.describe MXNet::Gluon::Loss::SoftmaxCrossEntropyLoss do
-  describe '#[]' do
+  describe '#call' do
     let(:loss) do
       described_class.new
     end
     it 'calculates softmax cross-entropy loss' do
       prediction = MXNet::NDArray.array([0, 1, 0])
       label = MXNet::NDArray.array([1])
-      expect(loss[prediction, label].as_scalar).to be_within(0.001).of(0.551)
+      expect(loss.call(prediction, label).as_scalar).to be_within(0.001).of(0.551)
     end
     context 'when created with `sparse_label: false`' do
       let(:loss) do
@@ -44,7 +44,7 @@ RSpec.describe MXNet::Gluon::Loss::SoftmaxCrossEntropyLoss do
       it 'calculates softmax cross-entropy loss' do
         prediction = MXNet::NDArray.array([0, 1, 0])
         label = MXNet::NDArray.array([0, 1, 0])
-        expect(loss[prediction, label].as_scalar).to be_within(0.001).of(0.551)
+        expect(loss.call(prediction, label).as_scalar).to be_within(0.001).of(0.551)
       end
     end
     context 'when created with `from_logits: true`' do
@@ -54,7 +54,7 @@ RSpec.describe MXNet::Gluon::Loss::SoftmaxCrossEntropyLoss do
       it 'calculates softmax cross-entropy loss' do
         prediction = MXNet::NDArray.array([0, -1, 0])
         label = MXNet::NDArray.array([1])
-        expect(loss[prediction, label].as_scalar).to be_within(0.001).of(1.000)
+        expect(loss.call(prediction, label).as_scalar).to be_within(0.001).of(1.000)
       end
     end
   end

--- a/spec/mxnet/gluon/loss_spec.rb
+++ b/spec/mxnet/gluon/loss_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe MXNet::Gluon::Loss::SoftmaxCrossEntropyLoss do
         described_class.new(from_logits: true)
       end
       it 'calculates softmax cross-entropy loss' do
-        prediction = MXNet::NDArray.array([0.0, -1.0, 0.0])
+        prediction = MXNet::NDArray.array([0, -1, 0])
         label = MXNet::NDArray.array([1])
         expect(loss[prediction, label].as_scalar).to be_within(0.001).of(1.000)
       end

--- a/spec/mxnet/gluon/loss_spec.rb
+++ b/spec/mxnet/gluon/loss_spec.rb
@@ -1,15 +1,61 @@
 require 'spec_helper'
 require 'mxnet/gluon/loss'
 
-RSpec.describe MXNet::Gluon::Loss::L2Loss do
-  describe '#hybrid_forward' do
+RSpec.describe MXNet::Gluon::Loss::L1Loss do
+  describe '#[]' do
     let(:loss) do
-      MXNet::Gluon::Loss::L2Loss.new
+      described_class.new
+    end
+    it 'calculates L1 loss' do
+      prediction = MXNet::NDArray.array([1])
+      label = MXNet::NDArray.array([2])
+      expect(loss[prediction, label].as_scalar).to eq(1.0)
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::Loss::L2Loss do
+  describe '#[]' do
+    let(:loss) do
+      described_class.new
     end
     it 'calculates L2 loss' do
       prediction = MXNet::NDArray.array([1])
       label = MXNet::NDArray.array([2])
-      expect(loss.hybrid_forward(MXNet::NDArray, prediction, label).to_a).to eq([0.5])
+      expect(loss[prediction, label].as_scalar).to eq(0.5)
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::Loss::SoftmaxCrossEntropyLoss do
+  describe '#[]' do
+    let(:loss) do
+      described_class.new
+    end
+    it 'calculates softmax cross-entropy loss' do
+      prediction = MXNet::NDArray.array([0, 1, 0])
+      label = MXNet::NDArray.array([1])
+      expect(loss[prediction, label].as_scalar).to be_within(0.001).of(0.551)
+    end
+    context 'when created with `sparse_label: false`' do
+      let(:loss) do
+        described_class.new(sparse_label: false)
+      end
+      it 'calculates softmax cross-entropy loss' do
+        prediction = MXNet::NDArray.array([0, 1, 0])
+        label = MXNet::NDArray.array([0, 1, 0])
+        expect(loss[prediction, label].as_scalar).to be_within(0.001).of(0.551)
+      end
+    end
+    context 'when created with `from_logits: true`' do
+      let(:loss) do
+        described_class.new(from_logits: true)
+      end
+      it 'calculates softmax cross-entropy loss' do
+        prediction = MXNet::NDArray.array([0.0, -1.0, 0.0])
+        label = MXNet::NDArray.array([1])
+        expect(loss[prediction, label].as_scalar).to be_within(0.001).of(1.000)
+      end
     end
   end
 end

--- a/spec/mxnet/gluon/nn/activations_spec.rb
+++ b/spec/mxnet/gluon/nn/activations_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'mxnet/gluon/nn/activations'
+
+RSpec.describe MXNet::Gluon::NN::Activation do
+  describe '.new' do
+    it 'accepts a string' do
+      act = MXNet::Gluon::NN::Activation.new('relu')
+      expect(act.forward(MXNet::NDArray.array([-1, 0, 1])))
+        .to eq(MXNet::NDArray.array([0, 0, 1]))
+    end
+    it 'accepts a symbol' do
+      act = MXNet::Gluon::NN::Activation.new(:relu)
+      expect(act.forward(MXNet::NDArray.array([-1, 0, 1])))
+        .to eq(MXNet::NDArray.array([0, 0, 1]))
+    end
+  end
+end

--- a/spec/mxnet/gluon/nn/activations_spec.rb
+++ b/spec/mxnet/gluon/nn/activations_spec.rb
@@ -4,12 +4,12 @@ require 'mxnet/gluon/nn/activations'
 RSpec.describe MXNet::Gluon::NN::Activation do
   describe '.new' do
     it 'accepts a string' do
-      act = MXNet::Gluon::NN::Activation.new('relu')
+      act = described_class.new('relu')
       expect(act.forward(MXNet::NDArray.array([-1, 0, 1])))
         .to eq(MXNet::NDArray.array([0, 0, 1]))
     end
     it 'accepts a symbol' do
-      act = MXNet::Gluon::NN::Activation.new(:relu)
+      act = described_class.new(:relu)
       expect(act.forward(MXNet::NDArray.array([-1, 0, 1])))
         .to eq(MXNet::NDArray.array([0, 0, 1]))
     end

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'mxnet/gluon/parameter'
+require 'mxnet/gluon/nn/layers'
+
+RSpec.describe MXNet::Gluon::NN::Dense do
+  describe 'Dense()' do
+    let(:layer) do
+      MXNet::Gluon::NN::Dense(1, in_units: 2)
+    end
+    specify do
+      expect(layer.class).to eq(MXNet::Gluon::NN::Dense)
+    end
+    it 'should set the weight and bias' do
+      expect(layer.weight.shape).to eq([1, 2])
+      expect(layer.bias.shape).to eq([1])
+    end
+  end
+  describe '#collect_params' do
+    let(:layer) do
+      MXNet::Gluon::NN::Dense(1, in_units: 2)
+    end
+    it 'should return params for weight and bias' do
+      params = MXNet::Gluon::ParameterDict.new(prefix: 'dense_').tap do |params|
+        params.get('weight', shape: [1, 2])
+        params.get('bias', shape: [1])
+      end
+      expect(layer.collect_params).to eq(params)
+    end
+  end
+  describe '#forward' do
+    let(:layer) do
+      MXNet::Gluon::NN::Dense(1, in_units: 2).tap do |layer|
+        layer.collect_params.init
+      end
+    end
+    it 'runs a forward pass' do
+      data = MXNet::NDArray.array([[2, 1]])
+      expect(layer.forward(data)).to be_a(MXNet::NDArray)
+    end
+  end
+  describe '#hybrid_forward' do
+    let(:layer) do
+      MXNet::Gluon::NN::Dense(1)
+    end
+    it 'accepts keyword arguments' do
+      data = MXNet::NDArray.array([[2, 1]])
+      kwargs = {
+        weight: MXNet::NDArray.array([[0.5, 0.5]]),
+        bias: MXNet::NDArray.array([-1])
+      }
+      expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a).to eq([[0.5]])
+    end
+    it 'accepts positional arguments' do
+      data = MXNet::NDArray.array([[2, 1]])
+      weight = MXNet::NDArray.array([[0.5, 0.5]])
+      bias = MXNet::NDArray.array([-1])
+      expect(layer.hybrid_forward(MXNet::NDArray, data, weight, bias).to_narray.to_a).to eq([[0.5]])
+    end
+  end
+end

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe MXNet::Gluon::NN do
       expect(layer).to be_a(MXNet::Gluon::NN::Sequential)
     end
   end
+
   describe '.Dense' do
     let(:layer) do
       MXNet::Gluon::NN.Dense(1)
@@ -34,6 +35,7 @@ RSpec.describe MXNet::Gluon::NN::Sequential do
       expect(layer.children).to eq([block])
     end
   end
+
   describe '#forward' do
     let(:layer) do
       described_class.new
@@ -62,6 +64,7 @@ RSpec.describe MXNet::Gluon::NN::HybridSequential do
       expect(layer.children).to eq([block])
     end
   end
+
   describe '#forward' do
     let(:layer) do
       described_class.new
@@ -112,6 +115,7 @@ RSpec.describe MXNet::Gluon::NN::Dense do
       end
     end
   end
+
   describe '#collect_params' do
     let(:layer) do
       described_class.new(1, in_units: 2, prefix: 'dense_')
@@ -124,6 +128,7 @@ RSpec.describe MXNet::Gluon::NN::Dense do
       expect(layer.collect_params).to eq(params)
     end
   end
+
   describe '#forward' do
     context 'with input units specified' do
       let(:layer) do
@@ -148,6 +153,7 @@ RSpec.describe MXNet::Gluon::NN::Dense do
       end
     end
   end
+
   describe '#hybrid_forward' do
     let(:layer) do
       described_class.new(1)
@@ -192,6 +198,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
   let(:newargs) do
     {channels: 1, kernel_size: [2, 2], strides: 1, padding: 0, dilation: 1, layout: 'NCHW'}
   end
+
   describe '.new' do
     let(:layer) do
       described_class.new(**newargs)
@@ -226,6 +233,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
       end
     end
   end
+
   describe '#hybrid_forward' do
     let(:layer) do
       described_class.new(**newargs)
@@ -239,6 +247,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
     let(:bias) do
       MXNet::NDArray.array([-1])
     end
+
     context 'without bias' do
       let(:kwargs) do
         {weight: weight}
@@ -254,6 +263,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
           .to eq(output)
       end
     end
+
     context 'with bias' do
       let(:kwargs) do
         {weight: weight, bias: bias}
@@ -269,6 +279,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
           .to eq(output)
       end
     end
+
     context 'with `strides: 2`' do
       let(:layer) do
         described_class.new(**newargs.merge(strides: 2))
@@ -286,6 +297,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
           .to eq(output)
       end
     end
+
     context 'with `padding: 1`' do
       let(:layer) do
         described_class.new(**newargs.merge(padding: 1))
@@ -306,6 +318,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
           .to eq(output)
       end
     end
+
     context 'with `dilation: 2`' do
       let(:layer) do
         described_class.new(**newargs.merge(dilation: 2))
@@ -330,6 +343,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Pooling do
   let(:newargs) do
     {pool_size: [2, 2], strides: 2, padding: 0}
   end
+
   describe '#hybrid_forward' do
     let(:layer) do
       described_class.new(**newargs)
@@ -346,6 +360,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Pooling do
       expect(layer.hybrid_forward(MXNet::NDArray, data).to_narray.to_a)
         .to eq(output)
     end
+
     context 'with `strides: 1`' do
       let(:layer) do
         described_class.new(**newargs.merge(strides: 1))
@@ -361,6 +376,7 @@ RSpec.describe MXNet::Gluon::NN::Internal::Pooling do
           .to eq(output)
       end
     end
+
     context 'with `padding: 1`' do
       let(:layer) do
         described_class.new(**newargs.merge(padding: 1))

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -3,16 +3,46 @@ require 'mxnet/gluon/parameter'
 require 'mxnet/gluon/nn/layers'
 
 RSpec.describe MXNet::Gluon::NN::Dense do
-  describe 'Dense()' do
+  describe 'Dense' do
     let(:layer) do
-      MXNet::Gluon::NN::Dense(1, in_units: 2)
+      MXNet::Gluon::NN::Dense(1)
     end
     specify do
       expect(layer.class).to eq(MXNet::Gluon::NN::Dense)
     end
+  end
+  describe '.new' do
+    let(:layer) do
+      MXNet::Gluon::NN::Dense.new(1)
+    end
     it 'should set the weight and bias' do
-      expect(layer.weight.shape).to eq([1, 2])
+      expect(layer.weight.shape).to eq([1, 0])
       expect(layer.bias.shape).to eq([1])
+    end
+    context 'for "in_units"' do
+      let(:layer) do
+        MXNet::Gluon::NN::Dense.new(1, in_units: 2)
+      end
+      it 'should set the weight and bias' do
+        expect(layer.weight.shape).to eq([1, 2])
+        expect(layer.bias.shape).to eq([1])
+      end
+    end
+    context 'for "use_bias"' do
+      let(:layer) do
+        MXNet::Gluon::NN::Dense.new(1, use_bias: false)
+      end
+      it 'should disable bias' do
+        expect(layer.bias).to be_nil
+      end
+    end
+    context 'for "activation"' do
+      let(:layer) do
+        MXNet::Gluon::NN::Dense.new(1, activation: :relu)
+      end
+      it 'add activation' do
+        expect(layer.act).to be_a(MXNet::Gluon::NN::Activation)
+      end
     end
   end
   describe '#collect_params' do

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe MXNet::Gluon::NN::Dense do
   end
   describe '#collect_params' do
     let(:layer) do
-      MXNet::Gluon::NN::Dense(1, in_units: 2)
+      MXNet::Gluon::NN::Dense(1, in_units: 2, prefix: 'dense_')
     end
     it 'should return params for weight and bias' do
       params = MXNet::Gluon::ParameterDict.new(prefix: 'dense_').tap do |params|

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -24,7 +24,7 @@ end
 RSpec.describe MXNet::Gluon::NN::Sequential do
   describe '#add' do
     let(:layer) do
-      MXNet::Gluon::NN::Sequential.new
+      described_class.new
     end
     let(:block) do
       MXNet::Gluon::Block.new
@@ -36,7 +36,7 @@ RSpec.describe MXNet::Gluon::NN::Sequential do
   end
   describe '#forward' do
     let(:layer) do
-      MXNet::Gluon::NN::Sequential.new
+      described_class.new
     end
     let(:block) do
       MXNet::Gluon::Block.new
@@ -52,32 +52,32 @@ end
 RSpec.describe MXNet::Gluon::NN::Dense do
   describe '.new' do
     let(:layer) do
-      MXNet::Gluon::NN::Dense.new(1)
+      described_class.new(1)
     end
     it 'should set the weight and bias' do
       expect(layer.weight.shape).to eq([1, 0])
       expect(layer.bias.shape).to eq([1])
     end
-    context 'for "in_units"' do
+    context 'with `in_units: 2`' do
       let(:layer) do
-        MXNet::Gluon::NN::Dense.new(1, in_units: 2)
+        described_class.new(1, in_units: 2)
       end
       it 'should set the weight and bias' do
         expect(layer.weight.shape).to eq([1, 2])
         expect(layer.bias.shape).to eq([1])
       end
     end
-    context 'for "use_bias"' do
+    context 'with `use_bias: false`' do
       let(:layer) do
-        MXNet::Gluon::NN::Dense.new(1, use_bias: false)
+        described_class.new(1, use_bias: false)
       end
       it 'should disable bias' do
         expect(layer.bias).to be_nil
       end
     end
-    context 'for "activation"' do
+    context 'with `activation: :relu`' do
       let(:layer) do
-        MXNet::Gluon::NN::Dense.new(1, activation: :relu)
+        described_class.new(1, activation: :relu)
       end
       it 'add activation' do
         expect(layer.act).to be_a(MXNet::Gluon::NN::Activation)
@@ -86,7 +86,7 @@ RSpec.describe MXNet::Gluon::NN::Dense do
   end
   describe '#collect_params' do
     let(:layer) do
-      MXNet::Gluon::NN::Dense(1, in_units: 2, prefix: 'dense_')
+      described_class.new(1, in_units: 2, prefix: 'dense_')
     end
     it 'should return params for weight and bias' do
       params = MXNet::Gluon::ParameterDict.new(prefix: 'dense_').tap do |params|
@@ -99,7 +99,7 @@ RSpec.describe MXNet::Gluon::NN::Dense do
   describe '#forward' do
     context 'with input units specified' do
       let(:layer) do
-        MXNet::Gluon::NN::Dense(1, in_units: 2).tap do |layer|
+        described_class.new(1, in_units: 2).tap do |layer|
           layer.collect_params.init
         end
       end
@@ -110,7 +110,7 @@ RSpec.describe MXNet::Gluon::NN::Dense do
     end
     context 'with input units inferred' do
       let(:layer) do
-        MXNet::Gluon::NN::Dense(1).tap do |layer|
+        described_class.new(1).tap do |layer|
           layer.collect_params.init
         end
       end
@@ -122,7 +122,7 @@ RSpec.describe MXNet::Gluon::NN::Dense do
   end
   describe '#hybrid_forward' do
     let(:layer) do
-      MXNet::Gluon::NN::Dense(1)
+      described_class.new(1)
     end
     it 'accepts keyword arguments' do
       data = MXNet::NDArray.array([[2, 1]])

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -49,6 +49,34 @@ RSpec.describe MXNet::Gluon::NN::Sequential do
   end
 end
 
+RSpec.describe MXNet::Gluon::NN::HybridSequential do
+  describe '#add' do
+    let(:layer) do
+      described_class.new
+    end
+    let(:block) do
+      MXNet::Gluon::HybridBlock.new
+    end
+    it 'should register block as a child' do
+      layer.add(block)
+      expect(layer.children).to eq([block])
+    end
+  end
+  describe '#forward' do
+    let(:layer) do
+      described_class.new
+    end
+    let(:block) do
+      MXNet::Gluon::HybridBlock.new
+    end
+    it 'should run a forward pass on its children' do
+      layer.add(block)
+      expect(block).to receive(:forward)
+      layer.forward(MXNet::Symbol.var('input'))
+    end
+  end
+end
+
 RSpec.describe MXNet::Gluon::NN::Dense do
   describe '.new' do
     let(:layer) do

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -133,19 +133,29 @@ RSpec.describe MXNet::Gluon::NN::Dense do
     let(:bias) do
       MXNet::NDArray.array([-1])
     end
-    let(:kwargs) do
-      {weight: weight, bias: bias}
+    context 'without bias' do
+      let(:kwargs) do
+        {weight: weight}
+      end
+      let(:output) do
+        [[1.5]]
+      end
+      it 'runs a forward pass' do
+        expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
+          .to eq(output)
+      end
     end
-    let(:output) do
-      [[0.5]]
-    end
-    it 'accepts keyword arguments' do
-      expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
-        .to eq(output)
-    end
-    it 'accepts positional arguments' do
-      expect(layer.hybrid_forward(MXNet::NDArray, data, weight, bias).to_narray.to_a)
-        .to eq(output)
+    context 'with bias' do
+      let(:kwargs) do
+        {weight: weight, bias: bias}
+      end
+      let(:output) do
+        [[0.5]]
+      end
+      it 'runs a forward pass' do
+        expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
+          .to eq(output)
+      end
     end
   end
 end
@@ -199,32 +209,48 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
       MXNet::NDArray.ones(4).reshape([1, 1, 2, 2])
     end
     let(:bias) do
-      MXNet::NDArray.zeros(1)
+      MXNet::NDArray.array([-1])
     end
-    let(:kwargs) do
-      {weight: weight, bias: bias}
+    context 'without bias' do
+      let(:kwargs) do
+        {weight: weight}
+      end
+      let(:output) do
+        [[[[10, 14, 18],
+           [26, 30, 34],
+           [42, 46, 50]
+          ]]]
+      end
+      it 'runs a forward pass' do
+        expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
+          .to eq(output)
+      end
     end
-    let(:output) do
-      [[[[10, 14, 18],
-         [26, 30, 34],
-         [42, 46, 50]
-        ]]]
-    end
-    it 'accepts keyword arguments' do
-      expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
-        .to eq(output)
-    end
-    it 'accepts positional arguments' do
-      expect(layer.hybrid_forward(MXNet::NDArray, data, weight, bias).to_narray.to_a)
-        .to eq(output)
+    context 'with bias' do
+      let(:kwargs) do
+        {weight: weight, bias: bias}
+      end
+      let(:output) do
+        [[[[ 9, 13, 17],
+           [25, 29, 33],
+           [41, 45, 49]
+          ]]]
+      end
+      it 'runs a forward pass' do
+        expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
+          .to eq(output)
+      end
     end
     context 'with `strides: 2`' do
       let(:layer) do
         described_class.new(**newargs.merge(strides: 2))
       end
+      let(:kwargs) do
+        {weight: weight, bias: bias}
+      end
       let(:output) do
-        [[[[10, 18],
-           [42, 50]
+        [[[[ 9, 17],
+           [41, 49]
           ]]]
       end
       it 'convolves with a stride of 2' do
@@ -236,12 +262,15 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
       let(:layer) do
         described_class.new(**newargs.merge(padding: 1))
       end
+      let(:kwargs) do
+        {weight: weight, bias: bias}
+      end
       let(:output) do
-        [[[[ 0,  1,  3,  5,  3],
-           [ 4, 10, 14, 18, 10],
-           [12, 26, 30, 34, 18],
-           [20, 42, 46, 50, 26],
-           [12, 25, 27, 29, 15]
+        [[[[-1,  0,  2,  4,  2],
+           [ 3,  9, 13, 17,  9],
+           [11, 25, 29, 33, 17],
+           [19, 41, 45, 49, 25],
+           [11, 24, 26, 28, 14]
           ]]]
       end
       it 'pads the input by 1' do
@@ -253,9 +282,12 @@ RSpec.describe MXNet::Gluon::NN::Internal::Conv do
       let(:layer) do
         described_class.new(**newargs.merge(dilation: 2))
       end
+      let(:kwargs) do
+        {weight: weight, bias: bias}
+      end
       let(:output) do
-        [[[[20, 24],
-           [36, 40]
+        [[[[19, 23],
+           [35, 39]
           ]]]
       end
       it 'dilation at a rate of 2' do

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -124,19 +124,215 @@ RSpec.describe MXNet::Gluon::NN::Dense do
     let(:layer) do
       described_class.new(1)
     end
+    let(:data) do
+      MXNet::NDArray.array([[2, 1]])
+    end
+    let(:weight) do
+      MXNet::NDArray.array([[0.5, 0.5]])
+    end
+    let(:bias) do
+      MXNet::NDArray.array([-1])
+    end
+    let(:kwargs) do
+      {weight: weight, bias: bias}
+    end
+    let(:output) do
+      [[0.5]]
+    end
     it 'accepts keyword arguments' do
-      data = MXNet::NDArray.array([[2, 1]])
-      kwargs = {
-        weight: MXNet::NDArray.array([[0.5, 0.5]]),
-        bias: MXNet::NDArray.array([-1])
-      }
-      expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a).to eq([[0.5]])
+      expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
+        .to eq(output)
     end
     it 'accepts positional arguments' do
-      data = MXNet::NDArray.array([[2, 1]])
-      weight = MXNet::NDArray.array([[0.5, 0.5]])
-      bias = MXNet::NDArray.array([-1])
-      expect(layer.hybrid_forward(MXNet::NDArray, data, weight, bias).to_narray.to_a).to eq([[0.5]])
+      expect(layer.hybrid_forward(MXNet::NDArray, data, weight, bias).to_narray.to_a)
+        .to eq(output)
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::NN::Internal::Conv do
+  let(:newargs) do
+    {channels: 1, kernel_size: [2, 2], strides: 1, padding: 0, dilation: 1, layout: 'NCHW'}
+  end
+  describe '.new' do
+    let(:layer) do
+      described_class.new(**newargs)
+    end
+    it 'should set the weight and bias' do
+      expect(layer.weight.shape).to eq([1, 0, 2, 2])
+      expect(layer.bias.shape).to eq([1])
+    end
+    context 'with `in_channels: 3`' do
+      let(:layer) do
+        described_class.new(**newargs.merge(in_channels: 3))
+      end
+      it 'should set the weight and bias' do
+        expect(layer.weight.shape).to eq([1, 3, 2, 2])
+        expect(layer.bias.shape).to eq([1])
+      end
+    end
+    context 'with `use_bias: false`' do
+      let(:layer) do
+        described_class.new(**newargs.merge(use_bias: false))
+      end
+      it 'should disable bias' do
+        expect(layer.bias).to be_nil
+      end
+    end
+    context 'with `activation: :relu`' do
+      let(:layer) do
+        described_class.new(**newargs.merge(activation: :relu))
+      end
+      it 'add activation' do
+        expect(layer.act).to be_a(MXNet::Gluon::NN::Activation)
+      end
+    end
+  end
+  describe '#hybrid_forward' do
+    let(:layer) do
+      described_class.new(**newargs)
+    end
+    let(:data) do
+      MXNet::NDArray.arange(16).reshape([1, 1, 4, 4])
+    end
+    let(:weight) do
+      MXNet::NDArray.ones(4).reshape([1, 1, 2, 2])
+    end
+    let(:bias) do
+      MXNet::NDArray.zeros(1)
+    end
+    let(:kwargs) do
+      {weight: weight, bias: bias}
+    end
+    let(:output) do
+      [[[[10, 14, 18],
+         [26, 30, 34],
+         [42, 46, 50]
+        ]]]
+    end
+    it 'accepts keyword arguments' do
+      expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
+        .to eq(output)
+    end
+    it 'accepts positional arguments' do
+      expect(layer.hybrid_forward(MXNet::NDArray, data, weight, bias).to_narray.to_a)
+        .to eq(output)
+    end
+    context 'with `strides: 2`' do
+      let(:layer) do
+        described_class.new(**newargs.merge(strides: 2))
+      end
+      let(:output) do
+        [[[[10, 18],
+           [42, 50]
+          ]]]
+      end
+      it 'convolves with a stride of 2' do
+        expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
+          .to eq(output)
+      end
+    end
+    context 'with `padding: 1`' do
+      let(:layer) do
+        described_class.new(**newargs.merge(padding: 1))
+      end
+      let(:output) do
+        [[[[ 0,  1,  3,  5,  3],
+           [ 4, 10, 14, 18, 10],
+           [12, 26, 30, 34, 18],
+           [20, 42, 46, 50, 26],
+           [12, 25, 27, 29, 15]
+          ]]]
+      end
+      it 'pads the input by 1' do
+        expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
+          .to eq(output)
+      end
+    end
+    context 'with `dilation: 2`' do
+      let(:layer) do
+        described_class.new(**newargs.merge(dilation: 2))
+      end
+      let(:output) do
+        [[[[20, 24],
+           [36, 40]
+          ]]]
+      end
+      it 'dilation at a rate of 2' do
+        expect(layer.hybrid_forward(MXNet::NDArray, data, kwargs).to_narray.to_a)
+          .to eq(output)
+      end
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::NN::Internal::Pooling do
+  let(:newargs) do
+    {pool_size: [2, 2], strides: 2, padding: 0}
+  end
+  describe '#hybrid_forward' do
+    let(:layer) do
+      described_class.new(**newargs)
+    end
+    let(:data) do
+      MXNet::NDArray.arange(16).reshape([1, 1, 4, 4])
+    end
+    let(:output) do
+      [[[[ 5,  7],
+         [13, 15]
+        ]]]
+    end
+    it 'pools the input' do
+      expect(layer.hybrid_forward(MXNet::NDArray, data).to_narray.to_a)
+        .to eq(output)
+    end
+    context 'with `strides: 1`' do
+      let(:layer) do
+        described_class.new(**newargs.merge(strides: 1))
+      end
+      let(:output) do
+        [[[[ 5,  6,  7],
+           [ 9, 10, 11],
+           [13, 14, 15]
+          ]]]
+      end
+      it 'pools with stride of 1' do
+        expect(layer.hybrid_forward(MXNet::NDArray, data).to_narray.to_a)
+          .to eq(output)
+      end
+    end
+    context 'with `padding: 1`' do
+      let(:layer) do
+        described_class.new(**newargs.merge(padding: 1))
+      end
+      let(:output) do
+        [[[[ 0,  2,  3],
+           [ 8, 10, 11],
+           [12, 14, 15]
+          ]]]
+      end
+      it 'pools with padding of 1' do
+        expect(layer.hybrid_forward(MXNet::NDArray, data).to_narray.to_a)
+          .to eq(output)
+      end
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::NN::Flatten do
+  describe '#hybrid_forward' do
+    let(:layer) do
+      described_class.new
+    end
+    let(:data) do
+      MXNet::NDArray.arange(16).reshape([1, 1, 4, 4])
+    end
+    let(:output) do
+      [[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]]
+    end
+    it 'flattens the input' do
+      expect(layer.hybrid_forward(MXNet::NDArray, data).to_narray.to_a)
+        .to eq(output)
     end
   end
 end

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -28,14 +28,27 @@ RSpec.describe MXNet::Gluon::NN::Dense do
     end
   end
   describe '#forward' do
-    let(:layer) do
-      MXNet::Gluon::NN::Dense(1, in_units: 2).tap do |layer|
-        layer.collect_params.init
+    context 'with input units specified' do
+      let(:layer) do
+        MXNet::Gluon::NN::Dense(1, in_units: 2).tap do |layer|
+          layer.collect_params.init
+        end
+      end
+      it 'runs a forward pass' do
+        data = MXNet::NDArray.array([[2, 1]])
+        expect(layer.forward(data)).to be_a(MXNet::NDArray)
       end
     end
-    it 'runs a forward pass' do
-      data = MXNet::NDArray.array([[2, 1]])
-      expect(layer.forward(data)).to be_a(MXNet::NDArray)
+    context 'with input units inferred' do
+      let(:layer) do
+        MXNet::Gluon::NN::Dense(1).tap do |layer|
+          layer.collect_params.init
+        end
+      end
+      it 'runs a forward pass' do
+        data = MXNet::NDArray.array([[2, 1]])
+        expect(layer.forward(data)).to be_a(MXNet::NDArray)
+      end
     end
   end
   describe '#hybrid_forward' do

--- a/spec/mxnet/gluon/nn/layers_spec.rb
+++ b/spec/mxnet/gluon/nn/layers_spec.rb
@@ -2,15 +2,54 @@ require 'spec_helper'
 require 'mxnet/gluon/parameter'
 require 'mxnet/gluon/nn/layers'
 
-RSpec.describe MXNet::Gluon::NN::Dense do
-  describe 'Dense' do
+RSpec.describe MXNet::Gluon::NN do
+  describe '.Sequential' do
     let(:layer) do
-      MXNet::Gluon::NN::Dense(1)
+      MXNet::Gluon::NN.Sequential
     end
     specify do
-      expect(layer.class).to eq(MXNet::Gluon::NN::Dense)
+      expect(layer).to be_a(MXNet::Gluon::NN::Sequential)
     end
   end
+  describe '.Dense' do
+    let(:layer) do
+      MXNet::Gluon::NN.Dense(1)
+    end
+    specify do
+      expect(layer).to be_a(MXNet::Gluon::NN::Dense)
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::NN::Sequential do
+  describe '#add' do
+    let(:layer) do
+      MXNet::Gluon::NN::Sequential.new
+    end
+    let(:block) do
+      MXNet::Gluon::Block.new
+    end
+    it 'should register block as a child' do
+      layer.add(block)
+      expect(layer.children).to eq([block])
+    end
+  end
+  describe '#forward' do
+    let(:layer) do
+      MXNet::Gluon::NN::Sequential.new
+    end
+    let(:block) do
+      MXNet::Gluon::Block.new
+    end
+    it 'should run a forward pass on its children' do
+      layer.add(block)
+      expect(block).to receive(:forward)
+      layer.forward(MXNet::Symbol.var('input'))
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::NN::Dense do
   describe '.new' do
     let(:layer) do
       MXNet::Gluon::NN::Dense.new(1)

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -47,6 +47,27 @@ RSpec.describe MXNet::Gluon::Parameter do
         end
       end
     end
+    context 'for "init"' do
+      let(:parameter) do
+        described_class.new('foo', shape: 1)
+      end
+      it 'accepts a class' do
+        parameter.init(init: MXNet::Initializer::Zero)
+        expect(parameter.data.to_a).to eq([0])
+      end
+      it 'accepts an instance' do
+        parameter.init(init: MXNet::Initializer::Zero.new)
+        expect(parameter.data.to_a).to eq([0])
+      end
+      it 'accepts a string' do
+        parameter.init(init: 'zeros')
+        expect(parameter.data.to_a).to eq([0])
+      end
+      it 'accepts a symbol' do
+        parameter.init(init: :zeros)
+        expect(parameter.data.to_a).to eq([0])
+      end
+    end
     context 'for "default_init"' do
       let(:parameter) do
         described_class.new('foo', shape: 1)

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -172,11 +172,13 @@ RSpec.describe MXNet::Gluon::ParameterDict do
     end
     context 'with a shared dict' do
       let(:shared_dict) do
-        MXNet::Gluon::ParameterDict.new
+        MXNet::Gluon::ParameterDict.new.tap do |shared_dict|
+          shared_dict.get('foo')
+        end
       end
       let(:parameter_dict) do
         MXNet::Gluon::ParameterDict.new(shared: shared_dict).tap do |parameter_dict|
-          shared_dict.get('foo')
+          parameter_dict.get('bar')
         end
       end
       it 'retrieves a parameter from the shared dict' do

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -47,6 +47,27 @@ RSpec.describe MXNet::Gluon::Parameter do
         end
       end
     end
+    context 'for "default_init"' do
+      let(:parameter) do
+        MXNet::Gluon::Parameter.new('foo', shape: 1)
+      end
+      it 'accepts a class' do
+        parameter.init(default_init: MXNet::Initializer::Zero)
+        expect(parameter.data.to_a).to eq([0])
+      end
+      it 'accepts an instance' do
+        parameter.init(default_init: MXNet::Initializer::Zero.new)
+        expect(parameter.data.to_a).to eq([0])
+      end
+      it 'accepts a string' do
+        parameter.init(default_init: 'zeros')
+        expect(parameter.data.to_a).to eq([0])
+      end
+      it 'accepts a symbol' do
+        parameter.init(default_init: :zeros)
+        expect(parameter.data.to_a).to eq([0])
+      end
+    end
   end
   describe '#list_ctx' do
     context 'without deferred initialization' do

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -9,21 +9,64 @@ RSpec.describe MXNet::Gluon::Parameter do
     end
   end
   describe '#init' do
-    let(:parameter) do
-      MXNet::Gluon::Parameter.new('foo', shape: [1])
+    context 'without deferred initialization' do
+      let(:parameter) do
+        MXNet::Gluon::Parameter.new('foo', shape: [1]).tap do |parameter|
+          parameter.init
+        end
+      end
+      it 'initializes the data array' do
+        expect(parameter.data).to be_a(MXNet::NDArray)
+      end
+      it 'initializes the grad array' do
+        expect(parameter.grad).to be_a(MXNet::NDArray)
+      end
+      it 'attaches grads' do
+        parameter.list_data.zip(parameter.list_grad).each do |p, g|
+          expect(p.grad).to eq(g)
+        end
+      end
     end
-    it 'initializes the data array' do
-      parameter.init
-      expect(parameter.data).to be_a(MXNet::NDArray)
+    context 'with deferred initialization' do
+      let(:parameter) do
+        MXNet::Gluon::Parameter.new('foo', allow_deferred_init: true).tap do |parameter|
+          parameter.init
+          parameter.shape = [1]
+          parameter.send(:finish_deferred_init)
+        end
+      end
+      it 'initializes the data array' do
+        expect(parameter.data).to be_a(MXNet::NDArray)
+      end
+      it 'initializes the grad array' do
+        expect(parameter.grad).to be_a(MXNet::NDArray)
+      end
+      it 'attaches grads' do
+        parameter.list_data.zip(parameter.list_grad).each do |p, g|
+          expect(p.grad).to eq(g)
+        end
+      end
     end
-    it 'initializes the grad array' do
-      parameter.init
-      expect(parameter.grad).to be_a(MXNet::NDArray)
+  end
+  describe '#list_ctx' do
+    context 'without deferred initialization' do
+      let(:parameter) do
+        MXNet::Gluon::Parameter.new('foo', shape: [1, 2]).tap do |parameter|
+          parameter.init
+        end
+      end
+      it 'returns the contexts' do
+        expect(parameter.list_ctx).to eq([MXNet.cpu])
+      end
     end
-    it 'attaches grads' do
-      parameter.init
-      parameter.list_data.zip(parameter.list_grad).each do |p, g|
-        expect(p.grad).to eq(g)
+    context 'with deferred initialization' do
+      let(:parameter) do
+        MXNet::Gluon::Parameter.new('foo', allow_deferred_init: true).tap do |parameter|
+          parameter.init
+        end
+      end
+      it 'returns the contexts' do
+        expect(parameter.list_ctx).to eq([MXNet.cpu])
       end
     end
   end
@@ -45,6 +88,54 @@ RSpec.describe MXNet::Gluon::Parameter do
     it 'returns the initialized data' do
       parameter.init
       expect(parameter.data).to be_a(MXNet::NDArray)
+    end
+  end
+  describe '#grad' do
+    let(:parameter) do
+      MXNet::Gluon::Parameter.new('foo', shape: [1])
+    end
+    it 'fails if the parameter has not been initialized' do
+      expect{parameter.grad}.to raise_error(RuntimeError)
+    end
+    it 'fails if the parameter has not been initialized on the specified context' do
+      parameter.init(ctx: MXNet.cpu)
+      expect{parameter.grad(ctx: MXNet.gpu)}.to raise_error(RuntimeError)
+    end
+    it 'succeeds if the parameter has been initialized on the specified context' do
+      parameter.init(ctx: MXNet.cpu)
+      expect{parameter.grad(ctx: MXNet.cpu)}.not_to raise_error
+    end
+    it 'returns the initialized grad' do
+      parameter.init
+      expect(parameter.grad).to be_a(MXNet::NDArray)
+    end
+  end
+  describe '#shape=' do
+    context 'with no shape' do
+      let(:parameter) do
+        MXNet::Gluon::Parameter.new('foo')
+      end
+      it 'assigns the shape' do
+        parameter.shape = [1, 2]
+        expect(parameter.shape).to eq([1, 2])
+      end
+    end
+    context 'with incomplete shape' do
+      let(:parameter) do
+        MXNet::Gluon::Parameter.new('foo', shape: [1, 0, 3])
+      end
+      it 'completes the shape' do
+        parameter.shape = [1, 2, 3]
+        expect(parameter.shape).to eq([1, 2, 3])
+      end
+    end
+    context 'with shape' do
+      let(:parameter) do
+        MXNet::Gluon::Parameter.new('foo', shape: [1, 2])
+      end
+      it 'raises an error' do
+        expect{parameter.shape = [1, 3]}.to raise_error(RuntimeError)
+      end
     end
   end
   describe '#==' do

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe MXNet::Gluon::Parameter do
       end
     end
   end
+  describe '#var' do
+    let(:parameter) do
+      described_class.new('foo')
+    end
+    it 'returns a symbol' do
+      expect(parameter.var).to be_a(MXNet::Symbol)
+    end
+    it 'has the symbolized name of the parameter' do
+      expect(parameter.var.name).to eq(:foo)
+    end
+  end
   describe '#data' do
     let(:parameter) do
       described_class.new('foo', shape: [1])
@@ -132,6 +143,22 @@ RSpec.describe MXNet::Gluon::Parameter do
       expect(parameter.data).to be_a(MXNet::NDArray)
     end
   end
+  describe '#set_data' do
+    let(:parameter) do
+      described_class.new('foo', shape: [1])
+    end
+    let(:data) do
+      MXNet::NDArray.ones([1])
+    end
+    it 'fails if the parameter has not been initialized' do
+      expect{parameter.set_data(data)}.to raise_error(RuntimeError)
+    end
+    it 'sets the data' do
+      parameter.init
+      parameter.set_data(data)
+      expect(parameter.data.to_a).to eq([1])
+    end
+  end
   describe '#grad' do
     let(:parameter) do
       described_class.new('foo', shape: [1])
@@ -150,6 +177,19 @@ RSpec.describe MXNet::Gluon::Parameter do
     it 'returns the initialized grad' do
       parameter.init
       expect(parameter.grad).to be_a(MXNet::NDArray)
+    end
+  end
+  describe '#zero_grad' do
+    let(:parameter) do
+      described_class.new('foo', shape: [1])
+    end
+    it 'fails if the parameter has not been initialized' do
+      expect{parameter.zero_grad}.to raise_error(RuntimeError)
+    end
+    it 'sets the grad' do
+      parameter.init
+      parameter.zero_grad
+      expect(parameter.grad.to_a).to eq([0])
     end
   end
   describe '#shape=' do

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MXNet::Gluon::Parameter do
       expect(described_class.new('test', shape: [1]).shape).to eq([1])
     end
   end
+
   describe '#init' do
     context 'without deferred initialization' do
       let(:parameter) do
@@ -27,6 +28,7 @@ RSpec.describe MXNet::Gluon::Parameter do
         end
       end
     end
+
     context 'with deferred initialization' do
       let(:parameter) do
         described_class.new('foo', allow_deferred_init: true).tap do |parameter|
@@ -47,6 +49,7 @@ RSpec.describe MXNet::Gluon::Parameter do
         end
       end
     end
+
     context 'with `grad_req: :null`' do
       let(:parameter) do
         described_class.new('foo', shape: [1], grad_req: :null).tap do |parameter|
@@ -60,6 +63,7 @@ RSpec.describe MXNet::Gluon::Parameter do
           .to raise_error(RuntimeError, /Cannot get gradient buffer/)
       end
     end
+
     context 'for "init"' do
       let(:parameter) do
         described_class.new('foo', shape: 1)
@@ -81,6 +85,7 @@ RSpec.describe MXNet::Gluon::Parameter do
         expect(parameter.data.to_a).to eq([0])
       end
     end
+
     context 'for "default_init"' do
       let(:parameter) do
         described_class.new('foo', shape: 1)
@@ -103,6 +108,7 @@ RSpec.describe MXNet::Gluon::Parameter do
       end
     end
   end
+
   describe '#list_ctx' do
     context 'without deferred initialization' do
       let(:parameter) do
@@ -125,6 +131,7 @@ RSpec.describe MXNet::Gluon::Parameter do
       end
     end
   end
+
   describe '#var' do
     let(:parameter) do
       described_class.new('foo')
@@ -136,6 +143,7 @@ RSpec.describe MXNet::Gluon::Parameter do
       expect(parameter.var.name).to eq(:foo)
     end
   end
+
   describe '#data' do
     let(:parameter) do
       described_class.new('foo', shape: [1])
@@ -156,6 +164,7 @@ RSpec.describe MXNet::Gluon::Parameter do
       expect(parameter.data).to be_a(MXNet::NDArray)
     end
   end
+
   describe '#set_data' do
     let(:parameter) do
       described_class.new('foo', shape: [1])
@@ -172,6 +181,7 @@ RSpec.describe MXNet::Gluon::Parameter do
       expect(parameter.data.to_a).to eq([1])
     end
   end
+
   describe '#grad' do
     let(:parameter) do
       described_class.new('foo', shape: [1])
@@ -192,6 +202,7 @@ RSpec.describe MXNet::Gluon::Parameter do
       expect(parameter.grad).to be_a(MXNet::NDArray)
     end
   end
+
   describe '#zero_grad' do
     let(:parameter) do
       described_class.new('foo', shape: [1])
@@ -205,6 +216,7 @@ RSpec.describe MXNet::Gluon::Parameter do
       expect(parameter.grad.to_a).to eq([0])
     end
   end
+
   describe '#shape=' do
     context 'with no shape' do
       let(:parameter) do
@@ -233,6 +245,7 @@ RSpec.describe MXNet::Gluon::Parameter do
       end
     end
   end
+
   describe '#==' do
     let(:parameter) do
       described_class.new('foo', shape: [1])
@@ -281,6 +294,7 @@ RSpec.describe MXNet::Gluon::ParameterDict do
       end
     end
   end
+
   describe '#update' do
     let(:parameter_dict) do
       described_class.new
@@ -299,6 +313,7 @@ RSpec.describe MXNet::Gluon::ParameterDict do
       expect{parameter_dict.update(other_dict)}.to raise_error(ArgumentError)
     end
   end
+
   describe '#init' do
     let(:parameter_dict) do
       described_class.new(prefix: 'name').tap do |parameter_dict|
@@ -310,6 +325,7 @@ RSpec.describe MXNet::Gluon::ParameterDict do
       expect(parameter_dict.get('foo').data).to be_a(MXNet::NDArray)
     end
   end
+
   describe '#==' do
     let(:parameter_dict) do
       described_class.new(prefix: 'name').tap do |parameter_dict|

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+require 'mxnet/gluon/parameter'
+
+RSpec.describe MXNet::Gluon::Parameter do
+  describe '.new' do
+    specify do
+      expect(MXNet::Gluon::Parameter.new('test', shape: 1).shape).to eq([1])
+      expect(MXNet::Gluon::Parameter.new('test', shape: [1]).shape).to eq([1])
+    end
+  end
+  describe '#init' do
+    let(:parameter) do
+      MXNet::Gluon::Parameter.new('foo', shape: [1])
+    end
+    it 'initializes the data array' do
+      parameter.init
+      expect(parameter.data).to be_a(MXNet::NDArray)
+    end
+  end
+  describe '#data' do
+    let(:parameter) do
+      MXNet::Gluon::Parameter.new('foo', shape: [1])
+    end
+    it 'fails if the parameter has not been initialized' do
+      expect{parameter.data}.to raise_error(RuntimeError)
+    end
+    it 'fails if the parameter has not been initialized on the specified context' do
+      parameter.init(ctx: MXNet.cpu)
+      expect{parameter.data(ctx: MXNet.gpu)}.to raise_error(RuntimeError)
+    end
+    it 'succeeds if the parameter has been initialized on the specified context' do
+      parameter.init(ctx: MXNet.cpu)
+      expect{parameter.data(ctx: MXNet.cpu)}.not_to raise_error
+    end
+    it 'returns the initialized data' do
+      parameter.init
+      expect(parameter.data).to be_a(MXNet::NDArray)
+    end
+  end
+  describe '#==' do
+    let(:parameter) do
+      MXNet::Gluon::Parameter.new('foo', shape: [1])
+    end
+    it 'is true if name and shape are equal' do
+      expect(parameter == MXNet::Gluon::Parameter.new('foo', shape: [1])).to be(true)
+    end
+    it 'is false if name is not equal' do
+      expect(parameter == MXNet::Gluon::Parameter.new('boo', shape: [1])).to be(false)
+    end
+    it 'is false if shape is not equal' do
+      expect(parameter == MXNet::Gluon::Parameter.new('foo', shape: [2])).to be(false)
+    end
+  end
+end
+
+RSpec.describe MXNet::Gluon::ParameterDict do
+  describe '#get' do
+    context 'without a shared dict' do
+      let(:parameter_dict) do
+        MXNet::Gluon::ParameterDict.new
+      end
+      it 'creates a new parameter if not in dict' do
+        expect(parameter_dict.get('foo')).to be_a(MXNet::Gluon::Parameter)
+      end
+      it 'retrieves a previously created parameter' do
+        expect(parameter_dict.get('bar')).to equal(parameter_dict.get('bar'))
+      end
+      it 'uses keyword arguments to create a parameter' do
+        expect(parameter_dict.get('baz', shape: [1, 1]).shape).to eq([1, 1])
+      end
+    end
+    context 'with a shared dict' do
+      let(:shared_dict) do
+        MXNet::Gluon::ParameterDict.new
+      end
+      let(:parameter_dict) do
+        MXNet::Gluon::ParameterDict.new(shared: shared_dict).tap do |parameter_dict|
+          shared_dict.get('foo')
+        end
+      end
+      it 'retrieves a parameter from the shared dict' do
+        expect(parameter_dict.get('foo')).to equal(shared_dict.get('foo'))
+      end
+    end
+  end
+  describe '#update' do
+    let(:parameter_dict) do
+      MXNet::Gluon::ParameterDict.new
+    end
+    let(:other_dict) do
+      MXNet::Gluon::ParameterDict.new.tap do |other_dict|
+        other_dict.get('foo', shape: 1)
+      end
+    end
+    it 'copies parameters into dict' do
+      parameter_dict.update(other_dict)
+      expect(parameter_dict.get('foo')).to equal(other_dict.get('foo'))
+    end
+    it 'fails if parameters already exist' do
+      parameter_dict.get('foo')
+      expect{parameter_dict.update(other_dict)}.to raise_error(ArgumentError)
+    end
+  end
+  describe '#init' do
+    let(:parameter_dict) do
+      MXNet::Gluon::ParameterDict.new(prefix: 'name').tap do |parameter_dict|
+        parameter_dict.get('foo', shape: 1)
+      end
+    end
+    it 'initializes all parameters' do
+      parameter_dict.init
+      expect(parameter_dict.get('foo').data).to be_a(MXNet::NDArray)
+    end
+  end
+  describe '#==' do
+    let(:parameter_dict) do
+      MXNet::Gluon::ParameterDict.new(prefix: 'name').tap do |parameter_dict|
+        parameter_dict.get('test')
+      end
+    end
+    it 'is true if prefix and items are equal' do
+      other_dict = MXNet::Gluon::ParameterDict.new(prefix: 'name').tap do |other_dict|
+        other_dict.get('test')
+      end
+      expect(parameter_dict == other_dict).to be(true)
+    end
+    it 'is false if prefix is not equal' do
+      other_dict = MXNet::Gluon::ParameterDict.new(prefix: 'other').tap do |other_dict|
+        other_dict.get('test')
+      end
+      expect(parameter_dict == other_dict).to be(false)
+    end
+    it 'is false items is not equal' do
+      other_dict = MXNet::Gluon::ParameterDict.new(prefix: 'name').tap do |other_dict|
+        other_dict.get('other')
+      end
+      expect(parameter_dict == other_dict).to be(false)
+    end
+  end
+end

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe MXNet::Gluon::Parameter do
       parameter.init
       expect(parameter.data).to be_a(MXNet::NDArray)
     end
+    it 'initializes the grad array' do
+      parameter.init
+      expect(parameter.grad).to be_a(MXNet::NDArray)
+    end
+    it 'attaches grads' do
+      parameter.init
+      parameter.list_data.zip(parameter.list_grad).each do |p, g|
+        expect(p.grad).to eq(g)
+      end
+    end
   end
   describe '#data' do
     let(:parameter) do

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -4,14 +4,14 @@ require 'mxnet/gluon/parameter'
 RSpec.describe MXNet::Gluon::Parameter do
   describe '.new' do
     specify do
-      expect(MXNet::Gluon::Parameter.new('test', shape: 1).shape).to eq([1])
-      expect(MXNet::Gluon::Parameter.new('test', shape: [1]).shape).to eq([1])
+      expect(described_class.new('test', shape: 1).shape).to eq([1])
+      expect(described_class.new('test', shape: [1]).shape).to eq([1])
     end
   end
   describe '#init' do
     context 'without deferred initialization' do
       let(:parameter) do
-        MXNet::Gluon::Parameter.new('foo', shape: [1]).tap do |parameter|
+        described_class.new('foo', shape: [1]).tap do |parameter|
           parameter.init
         end
       end
@@ -29,7 +29,7 @@ RSpec.describe MXNet::Gluon::Parameter do
     end
     context 'with deferred initialization' do
       let(:parameter) do
-        MXNet::Gluon::Parameter.new('foo', allow_deferred_init: true).tap do |parameter|
+        described_class.new('foo', allow_deferred_init: true).tap do |parameter|
           parameter.init
           parameter.shape = [1]
           parameter.send(:finish_deferred_init)
@@ -49,7 +49,7 @@ RSpec.describe MXNet::Gluon::Parameter do
     end
     context 'for "default_init"' do
       let(:parameter) do
-        MXNet::Gluon::Parameter.new('foo', shape: 1)
+        described_class.new('foo', shape: 1)
       end
       it 'accepts a class' do
         parameter.init(default_init: MXNet::Initializer::Zero)
@@ -72,7 +72,7 @@ RSpec.describe MXNet::Gluon::Parameter do
   describe '#list_ctx' do
     context 'without deferred initialization' do
       let(:parameter) do
-        MXNet::Gluon::Parameter.new('foo', shape: [1, 2]).tap do |parameter|
+        described_class.new('foo', shape: [1, 2]).tap do |parameter|
           parameter.init
         end
       end
@@ -82,7 +82,7 @@ RSpec.describe MXNet::Gluon::Parameter do
     end
     context 'with deferred initialization' do
       let(:parameter) do
-        MXNet::Gluon::Parameter.new('foo', allow_deferred_init: true).tap do |parameter|
+        described_class.new('foo', allow_deferred_init: true).tap do |parameter|
           parameter.init
         end
       end
@@ -93,7 +93,7 @@ RSpec.describe MXNet::Gluon::Parameter do
   end
   describe '#data' do
     let(:parameter) do
-      MXNet::Gluon::Parameter.new('foo', shape: [1])
+      described_class.new('foo', shape: [1])
     end
     it 'fails if the parameter has not been initialized' do
       expect{parameter.data}.to raise_error(RuntimeError)
@@ -113,7 +113,7 @@ RSpec.describe MXNet::Gluon::Parameter do
   end
   describe '#grad' do
     let(:parameter) do
-      MXNet::Gluon::Parameter.new('foo', shape: [1])
+      described_class.new('foo', shape: [1])
     end
     it 'fails if the parameter has not been initialized' do
       expect{parameter.grad}.to raise_error(RuntimeError)
@@ -134,7 +134,7 @@ RSpec.describe MXNet::Gluon::Parameter do
   describe '#shape=' do
     context 'with no shape' do
       let(:parameter) do
-        MXNet::Gluon::Parameter.new('foo')
+        described_class.new('foo')
       end
       it 'assigns the shape' do
         parameter.shape = [1, 2]
@@ -143,7 +143,7 @@ RSpec.describe MXNet::Gluon::Parameter do
     end
     context 'with incomplete shape' do
       let(:parameter) do
-        MXNet::Gluon::Parameter.new('foo', shape: [1, 0, 3])
+        described_class.new('foo', shape: [1, 0, 3])
       end
       it 'completes the shape' do
         parameter.shape = [1, 2, 3]
@@ -152,7 +152,7 @@ RSpec.describe MXNet::Gluon::Parameter do
     end
     context 'with shape' do
       let(:parameter) do
-        MXNet::Gluon::Parameter.new('foo', shape: [1, 2])
+        described_class.new('foo', shape: [1, 2])
       end
       it 'raises an error' do
         expect{parameter.shape = [1, 3]}.to raise_error(RuntimeError)
@@ -161,16 +161,16 @@ RSpec.describe MXNet::Gluon::Parameter do
   end
   describe '#==' do
     let(:parameter) do
-      MXNet::Gluon::Parameter.new('foo', shape: [1])
+      described_class.new('foo', shape: [1])
     end
     it 'is true if name and shape are equal' do
-      expect(parameter == MXNet::Gluon::Parameter.new('foo', shape: [1])).to be(true)
+      expect(parameter == described_class.new('foo', shape: [1])).to be(true)
     end
     it 'is false if name is not equal' do
-      expect(parameter == MXNet::Gluon::Parameter.new('boo', shape: [1])).to be(false)
+      expect(parameter == described_class.new('boo', shape: [1])).to be(false)
     end
     it 'is false if shape is not equal' do
-      expect(parameter == MXNet::Gluon::Parameter.new('foo', shape: [2])).to be(false)
+      expect(parameter == described_class.new('foo', shape: [2])).to be(false)
     end
   end
 end
@@ -179,7 +179,7 @@ RSpec.describe MXNet::Gluon::ParameterDict do
   describe '#get' do
     context 'without a shared dict' do
       let(:parameter_dict) do
-        MXNet::Gluon::ParameterDict.new
+        described_class.new
       end
       it 'creates a new parameter if not in dict' do
         expect(parameter_dict.get('foo')).to be_a(MXNet::Gluon::Parameter)
@@ -193,12 +193,12 @@ RSpec.describe MXNet::Gluon::ParameterDict do
     end
     context 'with a shared dict' do
       let(:shared_dict) do
-        MXNet::Gluon::ParameterDict.new.tap do |shared_dict|
+        described_class.new.tap do |shared_dict|
           shared_dict.get('foo')
         end
       end
       let(:parameter_dict) do
-        MXNet::Gluon::ParameterDict.new(shared: shared_dict).tap do |parameter_dict|
+        described_class.new(shared: shared_dict).tap do |parameter_dict|
           parameter_dict.get('bar')
         end
       end
@@ -209,10 +209,10 @@ RSpec.describe MXNet::Gluon::ParameterDict do
   end
   describe '#update' do
     let(:parameter_dict) do
-      MXNet::Gluon::ParameterDict.new
+      described_class.new
     end
     let(:other_dict) do
-      MXNet::Gluon::ParameterDict.new.tap do |other_dict|
+      described_class.new.tap do |other_dict|
         other_dict.get('foo', shape: 1)
       end
     end
@@ -227,7 +227,7 @@ RSpec.describe MXNet::Gluon::ParameterDict do
   end
   describe '#init' do
     let(:parameter_dict) do
-      MXNet::Gluon::ParameterDict.new(prefix: 'name').tap do |parameter_dict|
+      described_class.new(prefix: 'name').tap do |parameter_dict|
         parameter_dict.get('foo', shape: 1)
       end
     end
@@ -238,24 +238,24 @@ RSpec.describe MXNet::Gluon::ParameterDict do
   end
   describe '#==' do
     let(:parameter_dict) do
-      MXNet::Gluon::ParameterDict.new(prefix: 'name').tap do |parameter_dict|
+      described_class.new(prefix: 'name').tap do |parameter_dict|
         parameter_dict.get('test')
       end
     end
     it 'is true if prefix and items are equal' do
-      other_dict = MXNet::Gluon::ParameterDict.new(prefix: 'name').tap do |other_dict|
+      other_dict = described_class.new(prefix: 'name').tap do |other_dict|
         other_dict.get('test')
       end
       expect(parameter_dict == other_dict).to be(true)
     end
     it 'is false if prefix is not equal' do
-      other_dict = MXNet::Gluon::ParameterDict.new(prefix: 'other').tap do |other_dict|
+      other_dict = described_class.new(prefix: 'other').tap do |other_dict|
         other_dict.get('test')
       end
       expect(parameter_dict == other_dict).to be(false)
     end
     it 'is false items is not equal' do
-      other_dict = MXNet::Gluon::ParameterDict.new(prefix: 'name').tap do |other_dict|
+      other_dict = described_class.new(prefix: 'name').tap do |other_dict|
         other_dict.get('other')
       end
       expect(parameter_dict == other_dict).to be(false)

--- a/spec/mxnet/gluon/parameter_spec.rb
+++ b/spec/mxnet/gluon/parameter_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe MXNet::Gluon::Parameter do
         end
       end
     end
+    context 'with `grad_req: :null`' do
+      let(:parameter) do
+        described_class.new('foo', shape: [1], grad_req: :null).tap do |parameter|
+          parameter.init
+        end
+      end
+      it 'does not attach a grad array' do
+        expect{parameter.list_grad}
+          .to raise_error(RuntimeError, /Cannot get gradient buffers/)
+        expect{parameter.grad}
+          .to raise_error(RuntimeError, /Cannot get gradient buffer/)
+      end
+    end
     context 'for "init"' do
       let(:parameter) do
         described_class.new('foo', shape: 1)

--- a/spec/mxnet/gluon/trainer_spec.rb
+++ b/spec/mxnet/gluon/trainer_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'mxnet/gluon/trainer'
+
+RSpec.describe MXNet::Gluon::Trainer do
+  describe '#update' do
+    let(:parameter) do
+      MXNet::Gluon::Parameter.new('p', shape: [1]).tap do |param|
+        param.init
+      end
+    end
+    let(:optimizer) do
+      instance_double(MXNet::Optimizer).tap do |opt|
+        allow(opt).to receive(:is_a?).with(MXNet::Optimizer).and_return(true)
+        allow(opt).to receive(:rescale_grad=)
+      end
+    end
+    it 'calls Optimizer#update for every parameter' do
+      p = parameter
+      o = optimizer
+      expect(o).to receive(:update).with(0, p.data, p.grad, nil).exactly(1).times
+      trainer = MXNet::Gluon::Trainer.new({p: p}, o)
+      trainer.update(1)
+    end
+  end
+end

--- a/spec/mxnet/gluon/trainer_spec.rb
+++ b/spec/mxnet/gluon/trainer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe MXNet::Gluon::Trainer do
       p = parameter
       o = optimizer
       expect(o).to receive(:update).with(0, p.data, p.grad, nil).exactly(1).times
-      trainer = MXNet::Gluon::Trainer.new({p: p}, o)
+      trainer = described_class.new({p: p}, o)
       trainer.update(1)
     end
   end

--- a/spec/mxnet/initializer_spec.rb
+++ b/spec/mxnet/initializer_spec.rb
@@ -1,6 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe MXNet::Initializer do
+  describe '.create' do
+    it 'accepts a class' do
+      init = MXNet::Initializer.create(MXNet::Initializer::Zero)
+      expect(init).to be_a(MXNet::Initializer::Zero)
+    end
+    it 'accepts an instance' do
+      init = MXNet::Initializer.create(MXNet::Initializer::Zero.new)
+      expect(init).to be_a(MXNet::Initializer::Zero)
+    end
+    it 'accepts a string' do
+      init = MXNet::Initializer.create('zeros')
+      expect(init).to be_a(MXNet::Initializer::Zero)
+    end
+    it 'accepts a symbol' do
+      init = MXNet::Initializer.create(:zeros)
+      expect(init).to be_a(MXNet::Initializer::Zero)
+    end
+  end
   describe '#[]' do
     let(:initializer) do
       MXNet::Initializer.new

--- a/spec/mxnet/initializer_spec.rb
+++ b/spec/mxnet/initializer_spec.rb
@@ -3,25 +3,25 @@ require 'spec_helper'
 RSpec.describe MXNet::Initializer do
   describe '.create' do
     it 'accepts a class' do
-      init = MXNet::Initializer.create(MXNet::Initializer::Zero)
+      init = described_class.create(MXNet::Initializer::Zero)
       expect(init).to be_a(MXNet::Initializer::Zero)
     end
     it 'accepts an instance' do
-      init = MXNet::Initializer.create(MXNet::Initializer::Zero.new)
+      init = described_class.create(MXNet::Initializer::Zero.new)
       expect(init).to be_a(MXNet::Initializer::Zero)
     end
     it 'accepts a string' do
-      init = MXNet::Initializer.create('zeros')
+      init = described_class.create('zeros')
       expect(init).to be_a(MXNet::Initializer::Zero)
     end
     it 'accepts a symbol' do
-      init = MXNet::Initializer.create(:zeros)
+      init = described_class.create(:zeros)
       expect(init).to be_a(MXNet::Initializer::Zero)
     end
   end
   describe '#[]' do
     let(:initializer) do
-      MXNet::Initializer.new
+      described_class.new
     end
     it 'calls init_array' do
       array = MXNet::NDArray.array(1)

--- a/spec/mxnet/initializer_spec.rb
+++ b/spec/mxnet/initializer_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe MXNet::Initializer do
     end
   end
 
-  describe '#[]' do
+  describe '#call' do
     let(:initializer) do
       described_class.new
     end
     it 'calls init_array' do
       array = MXNet::NDArray.array(1)
       expect(initializer).to receive(:init_array).with(array)
-      initializer[array]
+      initializer.call(array)
     end
   end
 end

--- a/spec/mxnet/initializer_spec.rb
+++ b/spec/mxnet/initializer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe MXNet::Initializer do
       expect(init).to be_a(MXNet::Initializer::Zero)
     end
   end
+
   describe '#[]' do
     let(:initializer) do
       described_class.new

--- a/spec/mxnet/initializer_spec.rb
+++ b/spec/mxnet/initializer_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe MXNet::Initializer do
+  describe '#[]' do
+    let(:initializer) do
+      MXNet::Initializer.new
+    end
+    it 'calls init_array' do
+      array = MXNet::NDArray.array(1)
+      expect(initializer).to receive(:init_array).with(array)
+      initializer[array]
+    end
+  end
+end

--- a/spec/mxnet/optimizer_spec.rb
+++ b/spec/mxnet/optimizer_spec.rb
@@ -4,19 +4,19 @@ require 'mxnet/optimizer'
 RSpec.describe MXNet::Optimizer do
   describe '.create' do
     it 'accepts a class' do
-      opt = MXNet::Optimizer.create(MXNet::Optimizer::SGD)
+      opt = described_class.create(MXNet::Optimizer::SGD)
       expect(opt).to be_a(MXNet::Optimizer::SGD)
     end
     it 'accepts an instance' do
-      opt = MXNet::Optimizer.create(MXNet::Optimizer::SGD.new)
+      opt = described_class.create(MXNet::Optimizer::SGD.new)
       expect(opt).to be_a(MXNet::Optimizer::SGD)
     end
     it 'accepts a string' do
-      opt = MXNet::Optimizer.create('sgd')
+      opt = described_class.create('sgd')
       expect(opt).to be_a(MXNet::Optimizer::SGD)
     end
     it 'accepts a symbol' do
-      opt = MXNet::Optimizer.create(:sgd)
+      opt = described_class.create(:sgd)
       expect(opt).to be_a(MXNet::Optimizer::SGD)
     end
   end
@@ -25,7 +25,7 @@ end
 RSpec.describe MXNet::Optimizer::SGD do
   describe '#update' do
     let(:optimizer) do
-      MXNet::Optimizer::SGD.new(learning_rate: 0.1)
+      described_class.new(learning_rate: 0.1)
     end
     it 'updates the weight' do
       weight = MXNet::NDArray.array([1])

--- a/spec/mxnet/optimizer_spec.rb
+++ b/spec/mxnet/optimizer_spec.rb
@@ -1,10 +1,31 @@
 require 'spec_helper'
 require 'mxnet/optimizer'
 
-RSpec.describe MXNet::SGD do
+RSpec.describe MXNet::Optimizer do
+  describe '.create' do
+    it 'accepts a class' do
+      opt = MXNet::Optimizer.create(MXNet::Optimizer::SGD)
+      expect(opt).to be_a(MXNet::Optimizer::SGD)
+    end
+    it 'accepts an instance' do
+      opt = MXNet::Optimizer.create(MXNet::Optimizer::SGD.new)
+      expect(opt).to be_a(MXNet::Optimizer::SGD)
+    end
+    it 'accepts a string' do
+      opt = MXNet::Optimizer.create('sgd')
+      expect(opt).to be_a(MXNet::Optimizer::SGD)
+    end
+    it 'accepts a symbol' do
+      opt = MXNet::Optimizer.create(:sgd)
+      expect(opt).to be_a(MXNet::Optimizer::SGD)
+    end
+  end
+end
+
+RSpec.describe MXNet::Optimizer::SGD do
   describe '#update' do
     let(:optimizer) do
-      MXNet::SGD.new(learning_rate: 0.1)
+      MXNet::Optimizer::SGD.new(learning_rate: 0.1)
     end
     it 'updates the weight' do
       weight = MXNet::NDArray.array([1])

--- a/spec/mxnet/optimizer_spec.rb
+++ b/spec/mxnet/optimizer_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'mxnet/optimizer'
+
+RSpec.describe MXNet::SGD do
+  describe '#update' do
+    let(:optimizer) do
+      MXNet::SGD.new(learning_rate: 0.1)
+    end
+    it 'updates the weight' do
+      weight = MXNet::NDArray.array([1])
+      gradient = MXNet::NDArray.array([0.5])
+      expect(optimizer.update(0, weight, gradient, nil).as_scalar).to be_within(0.01).of(0.95)
+    end
+  end
+end

--- a/spec/mxnet/symbol_spec.rb
+++ b/spec/mxnet/symbol_spec.rb
@@ -144,6 +144,16 @@ module MXNet
       end
     end
 
+    describe '#compose' do
+      specify do
+        x = MXNet::Symbol.var(:x)
+        y = MXNet::Symbol.var(:y)
+        z = x * y
+        z.send(:compose, x: y)
+        expect(z.list_arguments).to eq([:y])
+      end
+    end
+
     describe '#list_arguments' do
       specify do
         x = MXNet::Symbol.var(:x)

--- a/spec/mxnet/symbol_spec.rb
+++ b/spec/mxnet/symbol_spec.rb
@@ -19,6 +19,16 @@ module MXNet
         expect(x.attr(:__dtype__)).to eq(MXNet::DType.name2id(:float64).to_s)
       end
 
+      specify do
+        x = MXNet::Symbol.var(:x, shape: [2, 3], dtype: 'float64')
+        expect(x.attr(:__dtype__)).to eq(MXNet::DType.name2id('float64').to_s)
+      end
+
+      specify do
+        x = MXNet::Symbol.var(:x, shape: [2, 3], dtype: 1)
+        expect(x.attr(:__dtype__)).to eq('1')
+      end
+
       specify 'symbol values in attributes are not allowed' do
         expect {
           MXNet::Symbol.var(:x, __foo__: :bar)


### PR DESCRIPTION
Enough Gluon to get through the first few chapters of The Straight Dope, including basic Perceptrons and CNNs. Also includes Python Gluon-compatible support for hybridization and export/import of models and parameters.

@mrkn mxnet.rb is an excellent library. Hopefully you find this a useful addition. I would appreciate feedback and comments, in any case.
