### PR TITLE
Spread Array Elements

### DIFF
--- a/lib/mxnet/gluon/data/data_loader.rb
+++ b/lib/mxnet/gluon/data/data_loader.rb
@@ -102,8 +102,8 @@ module MXNet
           when MXNet::NDArray
             return NDArray.stack(*data)
           when Array
-            data = data[0].zip(data[1..-1])
-            return data.map {|i| default_batchify_fn(i) }
+            data = data[0].zip(*data[1..-1])
+            return data.map { |i| default_batchify_fn(i) }
           else
             require 'mxnet/narray_helper'
             nary = Numo::NArray[*data]

--- a/spec/mxnet/gluon/data/data_loader_spec.rb
+++ b/spec/mxnet/gluon/data/data_loader_spec.rb
@@ -109,4 +109,14 @@ RSpec.describe MXNet::Gluon::Data::DataLoader do
       end
     end
   end
+
+  context 'with the MNIST dataset' do
+    let(:dataset) do
+      MXNet::Gluon::Data::Vision::MNIST.new
+    end
+
+    it 'should load the first examples' do
+      expect(loader.first).to eq([MXNet::NDArray.zeros([3, 28, 28, 1]), MXNet::NDArray.array([5, 0, 4], dtype: :int32)])
+    end
+  end
 end


### PR DESCRIPTION
Batch array elements must be spread correctly (transpose the array).

The bug manifests when using one of the built in datasets with the new loader.